### PR TITLE
Handle date and number types + semi-support deduplicated names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -360,6 +360,7 @@ fn extract_date_type(value: &JSONSchemaProps) -> Result<String> {
 }
 
 fn extract_number_type(value: &JSONSchemaProps) -> Result<String> {
+    // TODO: byte / password here?
     Ok(if let Some(f) = &value.format {
         match f.as_ref() {
             "float" => "f32".to_string(),
@@ -374,15 +375,20 @@ fn extract_number_type(value: &JSONSchemaProps) -> Result<String> {
 }
 
 fn extract_integer_type(value: &JSONSchemaProps) -> Result<String> {
-    // Think go types just do signed ints, but set a minimum to zero..
-    // rust will set uint though so emitting that when possbile
+    // Think kubernetes go types just do signed ints, but set a minimum to zero..
+    // rust will set uint, so emitting that when possbile
     Ok(if let Some(f) = &value.format {
         match f.as_ref() {
+            "int8" => "i8".to_string(),
+            "int16" => "i16".to_string(),
             "int32" => "i32".to_string(),
             "int64" => "i64".to_string(),
+            "int128" => "i128".to_string(),
+            "uint8" => "u8".to_string(),
+            "uint16" => "u16".to_string(),
             "uint32" => "u32".to_string(),
             "uint64" => "u64".to_string(),
-            // TODO: byte / password here?
+            "uint128" => "u128".to_string(),
             x => {
                 bail!("unknown integer {}", x);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,11 +375,13 @@ fn extract_number_type(value: &JSONSchemaProps) -> Result<String> {
 
 fn extract_integer_type(value: &JSONSchemaProps) -> Result<String> {
     // Think go types just do signed ints, but set a minimum to zero..
-    // TODO: look for minimum zero and use to set u32/u64
+    // rust will set uint though so emitting that when possbile
     Ok(if let Some(f) = &value.format {
         match f.as_ref() {
             "int32" => "i32".to_string(),
             "int64" => "i64".to_string(),
+            "uint32" => "u32".to_string(),
+            "uint64" => "u64".to_string(),
             // TODO: byte / password here?
             x => {
                 bail!("unknown integer {}", x);

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,10 +344,11 @@ fn array_recurse_for_type(value: &JSONSchemaProps, kind: &str, key: &str, level:
 
 fn extract_date_type(value: &JSONSchemaProps) -> Result<String> {
     Ok(if let Some(f) = &value.format {
+        // NB: these need chrono feature on serde
         match f.as_ref() {
-            // TODO: what type?
-            "date" => "String".to_string(),
-            // NB: needs chrono feature on serde
+            // Not sure if the first actually works properly..
+            // might need a Date<Utc> but chrono docs advocated for NaiveDate
+            "date" => "NaiveDate".to_string(),
             "date-time" => "DateTime<Utc>".to_string(),
             x => {
                 bail!("unknown date {}", x);


### PR DESCRIPTION
Cross-referencing types with https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/ + https://www.baeldung.com/openapi-dates

Got some best guess types for dates and date-times. Still lacking bytes, but don't see any CRDs using it, so leaving it as is for now.