### PR TITLE
ensure struct names are unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ rustfmt +nightly --edition 2021 prometheusrule.rs
 
 ## Output
 
-```rust
 use kube::CustomResource;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -42,19 +41,19 @@ use std::collections::BTreeMap;
 )]
 #[kube(namespaced)]
 #[kube(schema = "disabled")]
-pub struct PrometheusRuleSpec {
+pub struct PrometheusRuleSpecSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub groups: Vec<PrometheusRuleGroups>,
+    pub groups: Vec<PrometheusRuleSpecGroups>,
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PrometheusRuleGroups {
+pub struct PrometheusRuleSpecGroupsGroups {
     pub interval: Option<String>,
     pub name: String,
     pub partial_response_strategy: Option<String>,
-    pub rules: Vec<PrometheusRuleRules>,
+    pub rules: Vec<PrometheusRuleSpecGroupsRules>,
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PrometheusRuleRules {
+pub struct PrometheusRuleSpecGroupsRulesRules {
     pub alert: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub annotations: BTreeMap<String, String>,

--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ use std::collections::BTreeMap;
 )]
 #[kube(namespaced)]
 #[kube(schema = "disabled")]
-pub struct PrometheusRuleSpecSpec {
+pub struct PrometheusRuleSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub groups: Vec<PrometheusRuleSpecGroups>,
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PrometheusRuleSpecGroupsGroups {
+pub struct PrometheusRuleSpecGroups {
     pub interval: Option<String>,
     pub name: String,
     pub partial_response_strategy: Option<String>,
     pub rules: Vec<PrometheusRuleSpecGroupsRules>,
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PrometheusRuleSpecGroupsRulesRules {
+pub struct PrometheusRuleSpecGroupsRules {
     pub alert: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub annotations: BTreeMap<String, String>,

--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ use std::collections::BTreeMap;
 #[kube(schema = "disabled")]
 pub struct PrometheusRuleSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub groups: Vec<PrometheusRuleSpecGroups>,
+    pub groups: Vec<PrometheusRuleGroups>,
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PrometheusRuleSpecGroups {
+pub struct PrometheusRuleGroups {
     pub interval: Option<String>,
     pub name: String,
     pub partial_response_strategy: Option<String>,
-    pub rules: Vec<PrometheusRuleSpecGroupsRules>,
+    pub rules: Vec<PrometheusRuleGroupsRules>,
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PrometheusRuleSpecGroupsRules {
+pub struct PrometheusRuleGroupsRules {
     pub alert: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub annotations: BTreeMap<String, String>,

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ rustfmt +nightly --edition 2021 prometheusrule.rs
 
 ## Output
 
+```rust
 use kube::CustomResource;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 [![CI](https://github.com/kube-rs/kopium/actions/workflows/release.yml/badge.svg)](https://github.com/kube-rs/kopium/actions/workflows/release.yml)
 [![Crates.io](https://img.shields.io/crates/v/kopium.svg)](https://crates.io/crates/kopium)
 
+**K**ubernetes **op**enap**i** **u**n**m**angler.
 
-A **k**ubernetes **op**enap**i** **u**n**m**angler.
+Generates rust structs from `customresourcedefinitions` in your kubernetes cluster follwing the spec/status model, by using their embedded openapi schema.
 
-Creates rust structs from a named crd by converting the live openapi schema.
+**⚠️ WARNING: [ALPHA SOFTWARE](https://github.com/kube-rs/kopium/issues) ⚠️**
 
+Requirements:
 
-**⚠️ WARNING: ALPHA SOFTWARE ⚠️**
+- stable `customresourcedefinition` ([v1beta1 was removed in v1.22](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/))
+- crd with spec/status
 
 ## Installation
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -66,9 +66,7 @@ pub fn analyze(
                     if let Some(dict) = dict_key {
                         format!("BTreeMap<String, {}>", dict)
                     } else {
-                        // need to find the deterministic name for the struct
-                        let structsuffix = uppercase_first_letter(key);
-                        format!("{}{}", stack, structsuffix)
+                        stack.to_string()
                     }
                 }
                 "string" => "String".to_string(),

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,3 +1,4 @@
+//! Deals entirely with schema analysis for the purpose of creating output structs + members
 use crate::{OutputMember, OutputStruct};
 use anyhow::{bail, Result};
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
@@ -10,16 +11,14 @@ const IGNORED_KEYS: [&str; 3] = ["metadata", "apiVersion", "kind"];
 /// Scan a schema for structs and members, and recurse to find all structs
 ///
 /// schema: root schema / sub schema
-/// kind: crd kind name
-/// current: current key name (or empty string for first call)
-/// stackname: stacked concat of kind + current_{n-1} + ... + current (used to create dedup_name)
+/// current: current key name (or empty string for first call) - must capitalize first letter
+/// stack: stacked concat of kind + current_{n-1} + ... + current (used to create dedup names/types)
 /// level: recursion level (start at 0)
 /// results: multable list of generated structs (not deduplicated)
 pub fn analyze(
     schema: JSONSchemaProps,
-    kind: &str,
     current: &str,
-    stackname: &str,
+    stack: &str,
     level: u8,
     results: &mut Vec<OutputStruct>,
 ) -> Result<()> {
@@ -36,7 +35,7 @@ pub fn analyze(
             }
         }
         let mut members = vec![];
-        debug!("Generating struct for {} (under {})", current, stackname);
+        debug!("Generating struct for {} (under {})", current, stack);
 
         let reqs = schema.required.unwrap_or_default();
         // initial analysis of properties (we do not recurse here, we need to find members first)
@@ -67,9 +66,9 @@ pub fn analyze(
                     if let Some(dict) = dict_key {
                         format!("BTreeMap<String, {}>", dict)
                     } else {
-                        let structsuffix = uppercase_first_letter(key);
                         // need to find the deterministic name for the struct
-                        format!("{}{}", kind, structsuffix)
+                        let structsuffix = uppercase_first_letter(key);
+                        format!("{}{}", stack, structsuffix)
                     }
                 }
                 "string" => "String".to_string(),
@@ -79,7 +78,7 @@ pub fn analyze(
                 "integer" => extract_integer_type(value)?,
                 "array" => {
                     // recurse through repeated arrays until we find a concrete type (keep track of how deep we went)
-                    let (array_type, recurse_level) = array_recurse_for_type(value, kind, key, 1)?;
+                    let (array_type, recurse_level) = array_recurse_for_type(value, stack, key, 1)?;
                     debug!(
                         "got array type {} for {} in level {}",
                         array_type, key, recurse_level
@@ -136,8 +135,7 @@ pub fn analyze(
         }
         // Finalize struct with given members
         results.push(OutputStruct {
-            name: format!("{}{}", kind, current),
-            dedup_name: format!("{}{}", stackname, current),
+            name: format!("{}{}", stack, current),
             members,
             level,
         });
@@ -149,12 +147,12 @@ pub fn analyze(
             debug!("not recursing into ignored {}", key); // handled elsewhere
             continue;
         }
-        let next_current = uppercase_first_letter(&key);
-        let stackname = format!("{}{}", kind, current);
+        let next_key = uppercase_first_letter(&key);
+        let next_stack = format!("{}{}", stack, next_key);
         let value_type = value.type_.clone().unwrap_or_default();
         match value_type.as_ref() {
             "object" => {
-                analyze(value, kind, &next_current, &stackname, level + 1, results)?;
+                analyze(value, &next_key, &next_stack, level + 1, results)?;
             }
             "array" => {
                 if let Some(recurse) = array_recurse_level.get(&key).cloned() {
@@ -173,7 +171,7 @@ pub fn analyze(
                             bail!("could not recurse into vec");
                         }
                     }
-                    analyze(inner, kind, &next_current, &stackname, level + 1, results)?;
+                    analyze(inner, &next_key, &next_stack, level + 1, results)?;
                 }
             }
             "" => {
@@ -191,7 +189,12 @@ pub fn analyze(
 
 // recurse into an array type to find its nested type
 // this recursion is intialised and ended within a single step of the outer recursion
-fn array_recurse_for_type(value: &JSONSchemaProps, kind: &str, key: &str, level: u8) -> Result<(String, u8)> {
+fn array_recurse_for_type(
+    value: &JSONSchemaProps,
+    stack: &str,
+    key: &str,
+    level: u8,
+) -> Result<(String, u8)> {
     if let Some(items) = &value.items {
         match items {
             JSONSchemaPropsOrArray::Schema(s) => {
@@ -199,14 +202,14 @@ fn array_recurse_for_type(value: &JSONSchemaProps, kind: &str, key: &str, level:
                 return match inner_array_type.as_ref() {
                     "object" => {
                         let structsuffix = uppercase_first_letter(key);
-                        Ok((format!("Vec<{}{}>", kind, structsuffix), level))
+                        Ok((format!("Vec<{}{}>", stack, structsuffix), level))
                     }
                     "string" => Ok(("Vec<String>".into(), level)),
                     "boolean" => Ok(("Vec<bool>".into(), level)),
                     "date" => Ok((format!("Vec<{}>", extract_date_type(value)?), level)),
                     "number" => Ok((format!("Vec<{}>", extract_number_type(value)?), level)),
                     "integer" => Ok((format!("Vec<{}>", extract_integer_type(value)?), level)),
-                    "array" => Ok(array_recurse_for_type(s, kind, key, level + 1)?),
+                    "array" => Ok(array_recurse_for_type(s, stack, key, level + 1)?),
                     x => {
                         bail!("unsupported recursive array type {} for {}", x, key)
                     }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -146,11 +146,6 @@ pub fn analyze(
             continue;
         }
         let next_key = uppercase_first_letter(&key);
-        //let next_stack = if level == 0 && next_key == "Spec" {
-        //    stack.to_string() // leave Spec out of other structs
-        //} else {
-        //    format!("{}{}", stack, next_key)
-        //};
         let next_stack = format!("{}{}", stack, next_key);
         let value_type = value.type_.clone().unwrap_or_default();
         match value_type.as_ref() {

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -133,7 +133,7 @@ pub fn analyze(
         }
         // Finalize struct with given members
         results.push(OutputStruct {
-            name: format!("{}{}", stack, current),
+            name: stack.to_string(),
             members,
             level,
         });
@@ -146,6 +146,11 @@ pub fn analyze(
             continue;
         }
         let next_key = uppercase_first_letter(&key);
+        //let next_stack = if level == 0 && next_key == "Spec" {
+        //    stack.to_string() // leave Spec out of other structs
+        //} else {
+        //    format!("{}{}", stack, next_key)
+        //};
         let next_stack = format!("{}{}", stack, next_key);
         let value_type = value.type_.clone().unwrap_or_default();
         match value_type.as_ref() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 pub struct OutputStruct {
     // The short name of the struct (kind + capitalized suffix)
     pub name: String,
-    // The full (deduplicated) name of the struct (kind + recursive capitalized suffixes) - unused atm
-    pub dedup_name: String,
     pub level: u8,
     pub members: Vec<OutputMember>,
 }
@@ -16,8 +14,22 @@ pub struct OutputStruct {
 pub struct OutputMember {
     pub name: String,
     pub type_: String,
-    //pub dedup_type: String,
     pub field_annot: Option<String>,
 }
 
-pub mod analyzer;
+impl OutputStruct {
+    pub fn uses_btreemaps(&self) -> bool {
+        self.members.iter().any(|m| m.type_.contains("BTreeMap"))
+    }
+
+    pub fn uses_datetime(&self) -> bool {
+        self.members.iter().any(|m| m.type_.contains("DateTime"))
+    }
+
+    pub fn uses_date(&self) -> bool {
+        self.members.iter().any(|m| m.type_.contains("NaiveDate"))
+    }
+}
+
+mod analyzer;
+pub use analyzer::analyze;

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,10 +74,12 @@ async fn main() -> Result<()> {
                     // don't support grabbing original schema atm so disable schemas:
                     // (we coerce IntToString to String anyway so it wont match anyway)
                     println!(r#"#[kube(schema = "disabled")]"#);
+                    println!("pub struct {} {{", s.name);
                 } else {
                     println!("#[derive(Serialize, Deserialize, Clone, Debug)]");
+                    let spec_trimmed_name = s.name.as_str().replace(&format!("{}Spec", kind), &kind);
+                    println!("pub struct {} {{", spec_trimmed_name);
                 }
-                println!("pub struct {} {{", s.name);
                 for m in s.members {
                     if let Some(annot) = m.field_annot {
                         println!("    {}", annot);

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,8 @@ async fn main() -> Result<()> {
                     } else {
                         format_ident!("{}", m.name)
                     };
-                    println!("    pub {}: {},", safe_name, m.type_);
+                    let spec_trimmed_type = m.type_.as_str().replace(&format!("{}Spec", kind), &kind);
+                    println!("    pub {}: {},", safe_name, spec_trimmed_type);
                 }
                 println!("}}")
             }


### PR DESCRIPTION
Avoided having options to swap between unsafe naming conventions and others.

Going to instead look at introducing a way to trim initial prefixes from structs.