### PR TITLE
Add 'list-crds' and 'completions' subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ impl Kopium {
                 } else {
                     self.print_docstr(s.docs, "");
                     if s.level == 1 && s.name.ends_with("Spec") {
-                        print_derives(&self.derive);
+                        self.print_derives();
                         println!(
                             r#"#[kube(group = "{}", version = "{}", kind = "{}", plural = "{}")]"#,
                             group, version, kind, plural
@@ -139,6 +139,17 @@ impl Kopium {
             }
         }
     }
+
+    fn print_derives(&self) {
+        if self.derive.is_empty() {
+            println!("#[derive(CustomResource, Serialize, Deserialize, Clone, Debug)]");
+        } else {
+            println!(
+                "#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, {})]",
+                self.derive.join(", ")
+            );
+        }
+    }
 }
 
 
@@ -157,16 +168,6 @@ fn print_prelude(results: &[OutputStruct]) {
     println!();
 }
 
-fn print_derives(derives: &[String]) {
-    if derives.is_empty() {
-        println!("#[derive(CustomResource, Serialize, Deserialize, Clone, Debug)]");
-    } else {
-        println!(
-            "#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, {})]",
-            derives.join(", ")
-        );
-    }
-}
 
 fn find_crd_version<'a>(
     crd: &'a CustomResourceDefinition,

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,13 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+impl Kopium {
+    fn help(&self) -> Result<()> {
+        Self::clap().print_help().map(|_| println!())?;
+        Ok(())
+    }
+}
+
 fn print_docstr(args: &Kopium, doc: Option<String>, indent: &str) {
     // print doc strings if requested in arguments
     if args.docs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ const KEYWORDS: [&str; 23] = [
 )]
 struct Kopium {
     #[structopt(about = "Give the name of the input CRD to use e.g. prometheusrules.monitoring.coreos.com")]
-    crd: String,
+    crd: Option<String>,
     #[structopt(about = "Use this CRD version if multiple versions are present", long)]
     api_version: Option<String>,
     #[structopt(about = "Do not emit prelude", long)]
@@ -39,80 +39,92 @@ struct Kopium {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let kopium = Kopium::from_args();
-    let client = Client::try_default().await?;
-    let api: Api<CustomResourceDefinition> = Api::all(client);
-    let crd = api.get(&kopium.crd).await?;
-
-    let version = find_crd_version(&crd, kopium.api_version.as_deref())?;
-    let data = version
-        .schema
-        .as_ref()
-        .and_then(|schema| schema.open_api_v3_schema.clone());
-    let version = version.name.clone();
-
-    let kind = crd.spec.names.kind;
-    let plural = crd.spec.names.plural;
-    let group = crd.spec.group;
-    let scope = crd.spec.scope;
-
-    if let Some(schema) = data {
-        let mut structs = vec![];
-        log::debug!("schema: {}", serde_json::to_string_pretty(&schema)?);
-        analyze(schema, "", &kind, 0, &mut structs)?;
-
-        if !kopium.hide_prelude {
-            print_prelude(&structs);
-        }
-
-        for s in structs {
-            if s.level == 0 {
-                continue; // ignoring root struct
-            } else {
-                print_docstr(&kopium, s.docs, "");
-                if s.level == 1 && s.name.ends_with("Spec") {
-                    print_derives(&kopium.derive);
-                    println!(
-                        r#"#[kube(group = "{}", version = "{}", kind = "{}", plural = "{}")]"#,
-                        group, version, kind, plural
-                    );
-                    if scope == "Namespaced" {
-                        println!(r#"#[kube(namespaced)]"#);
-                    }
-                    // don't support grabbing original schema atm so disable schemas:
-                    // (we coerce IntToString to String anyway so it wont match anyway)
-                    println!(r#"#[kube(schema = "disabled")]"#);
-                    println!("pub struct {} {{", s.name);
-                } else {
-                    println!("#[derive(Serialize, Deserialize, Clone, Debug)]");
-                    let spec_trimmed_name = s.name.as_str().replace(&format!("{}Spec", kind), &kind);
-                    println!("pub struct {} {{", spec_trimmed_name);
-                }
-                for m in s.members {
-                    print_docstr(&kopium, m.docs, "    ");
-                    if let Some(annot) = m.field_annot {
-                        println!("    {}", annot);
-                    }
-                    let safe_name = if KEYWORDS.contains(&m.name.as_ref()) {
-                        format_ident!("r#{}", m.name)
-                    } else {
-                        format_ident!("{}", m.name)
-                    };
-                    let spec_trimmed_type = m.type_.as_str().replace(&format!("{}Spec", kind), &kind);
-                    println!("    pub {}: {},", safe_name, spec_trimmed_type);
-                }
-                println!("}}");
-                println!();
-            }
-        }
-    } else {
-        log::error!("no schema found for crd {}", kopium.crd);
-    }
-
-    Ok(())
+    Kopium::from_args().dispatch().await
 }
 
 impl Kopium {
+    async fn dispatch(&self) -> Result<()> {
+        let crds = Client::try_default()
+            .await
+            .map(Api::<CustomResourceDefinition>::all)?;
+        if let Some(name) = self.crd.as_deref() {
+            self.generate(crds, name).await
+        } else {
+            self.help()
+        }
+    }
+
+    async fn generate(&self, api: Api<CustomResourceDefinition>, name: &str) -> Result<()> {
+        let crd = api.get(name).await?;
+        let version = self.api_version.as_deref();
+        let version = find_crd_version(&crd, version)?;
+        let data = version
+            .schema
+            .as_ref()
+            .and_then(|schema| schema.open_api_v3_schema.clone());
+        let version = version.name.clone();
+
+        let kind = crd.spec.names.kind;
+        let plural = crd.spec.names.plural;
+        let group = crd.spec.group;
+        let scope = crd.spec.scope;
+
+        if let Some(schema) = data {
+            let mut structs = vec![];
+            log::debug!("schema: {}", serde_json::to_string_pretty(&schema)?);
+            analyze(schema, "", &kind, 0, &mut structs)?;
+
+            if !self.hide_prelude {
+                print_prelude(&structs);
+            }
+
+            for s in structs {
+                if s.level == 0 {
+                    continue; // ignoring root struct
+                } else {
+                    print_docstr(self, s.docs, "");
+                    if s.level == 1 && s.name.ends_with("Spec") {
+                        print_derives(&self.derive);
+                        println!(
+                            r#"#[kube(group = "{}", version = "{}", kind = "{}", plural = "{}")]"#,
+                            group, version, kind, plural
+                        );
+                        if scope == "Namespaced" {
+                            println!(r#"#[kube(namespaced)]"#);
+                        }
+                        // don't support grabbing original schema atm so disable schemas:
+                        // (we coerce IntToString to String anyway so it wont match anyway)
+                        println!(r#"#[kube(schema = "disabled")]"#);
+                        println!("pub struct {} {{", s.name);
+                    } else {
+                        println!("#[derive(Serialize, Deserialize, Clone, Debug)]");
+                        let spec_trimmed_name = s.name.as_str().replace(&format!("{}Spec", kind), &kind);
+                        println!("pub struct {} {{", spec_trimmed_name);
+                    }
+                    for m in s.members {
+                        print_docstr(self, m.docs, "    ");
+                        if let Some(annot) = m.field_annot {
+                            println!("    {}", annot);
+                        }
+                        let safe_name = if KEYWORDS.contains(&m.name.as_ref()) {
+                            format_ident!("r#{}", m.name)
+                        } else {
+                            format_ident!("{}", m.name)
+                        };
+                        let spec_trimmed_type = m.type_.as_str().replace(&format!("{}Spec", kind), &kind);
+                        println!("    pub {}: {},", safe_name, spec_trimmed_type);
+                    }
+                    println!("}}");
+                    println!();
+                }
+            }
+        } else {
+            log::error!("no schema found for crd {}", name);
+        }
+
+        Ok(())
+    }
+
     fn help(&self) -> Result<()> {
         Self::clap().print_help().map(|_| println!())?;
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ impl Kopium {
                 if s.level == 0 {
                     continue; // ignoring root struct
                 } else {
-                    print_docstr(self, s.docs, "");
+                    self.print_docstr(s.docs, "");
                     if s.level == 1 && s.name.ends_with("Spec") {
                         print_derives(&self.derive);
                         println!(
@@ -102,7 +102,7 @@ impl Kopium {
                         println!("pub struct {} {{", spec_trimmed_name);
                     }
                     for m in s.members {
-                        print_docstr(self, m.docs, "    ");
+                        self.print_docstr(m.docs, "    ");
                         if let Some(annot) = m.field_annot {
                             println!("    {}", annot);
                         }
@@ -129,17 +129,18 @@ impl Kopium {
         Self::clap().print_help().map(|_| println!())?;
         Ok(())
     }
-}
 
-fn print_docstr(args: &Kopium, doc: Option<String>, indent: &str) {
-    // print doc strings if requested in arguments
-    if args.docs {
-        if let Some(d) = doc {
-            println!("{}/// {}", indent, d);
-            // TODO: logic to split doc strings by sentence / length here
+    fn print_docstr(&self, doc: Option<String>, indent: &str) {
+        // print doc strings if requested in arguments
+        if self.docs {
+            if let Some(d) = doc {
+                println!("{}/// {}", indent, d);
+                // TODO: logic to split doc strings by sentence / length here
+            }
         }
     }
 }
+
 
 fn print_prelude(results: &[OutputStruct]) {
     println!("use kube::CustomResource;");


### PR DESCRIPTION
So this is my take on adding subcommands. I wish clap would support default subcommand, but that doesn't seem to work ATM, so code is a bit rougher than it could be otherwise.
Anyway, what do you think about the entire approach?

As for completions - right now it invokes clap's internal completion generation and that doesn't take into account crd names completion. That part needs to be coded manually for different types of shells and replaced/inserted during the completion generation process. Unfortunately, I have virtually no experience with writing the completions for any shell, so someone else's wisdom will be needed here.
