### PR TITLE
Add support for rust docstrings from description - fixes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ pub struct PrometheusRuleGroupsRules {
 }
 ```
 
+**Note**: Doc comments on members are also exported when they exist within the schema.
+
 ## Usage with kube
 
 Simply add the generated file (e.g. output from above in `prometheusrule.rs`) to your library, and import (at least) the special root type:

--- a/README.md
+++ b/README.md
@@ -86,10 +86,14 @@ Simply add the generated file (e.g. output from above in `prometheusrule.rs`) to
 use prometheusrule::PrometheusRule;
 use kube::{Api, Client, ResourceExt};
 
-let client = Client::try_default().await?;
-let pr: Api<PrometheusRule> = Api::default_namespaced(client);
-for p in pr.list(&Default::default()).await? {
-    println!("Found PrometheusRule {} in current namespace", p.name());
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::try_default().await?;
+    let pr: Api<PrometheusRule> = Api::default_namespaced(client);
+    for p in pr.list(&Default::default()).await? {
+        println!("Found PrometheusRule {} in current namespace", p.name());
+    }
+    Ok(())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Requirements:
 
 ## Features
 
-- **Instantly Queryable**: generated type uses [`kube-derive`](https://docs.rs/kube/latest/kube/derive.CustomResource.html) to provide api integration with `kube`
-- **Ergonomic Rust Types**: no unnecessary `Option` wrapping when `#[serde(default)]` on `Vec`/`BTreeMap` will suffice
-- **Rust doc strings**: optionally extracted from `description` values in schema (`--docs`)
+- **Instantly queryable**: generated type uses [`kube-derive`](https://docs.rs/kube/latest/kube/derive.CustomResource.html) to provide api integration with `kube`
+- **Ergonomic Rust types**: no unnecessary `Option` wrapping when `#[serde(default)]` on `Vec`/`BTreeMap` will suffice
+- **[Rust doc comments](https://doc.rust-lang.org/rust-by-example/meta/doc.html#doc-comments)**: optionally extracted from `description` values in schema (`--docs`)
 
 ## Installation
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -96,12 +96,14 @@ pub fn analyze(
             };
 
             // Create member and wrap types correctly
+            let member_doc = value.description.clone();
             if reqs.contains(key) {
                 debug!("with required member {} of type {}", key, rust_type);
                 members.push(OutputMember {
                     type_: rust_type,
                     name: key.to_string(),
                     field_annot: None,
+                    docstr: member_doc,
                 })
             } else {
                 // option wrapping possibly needed if not required
@@ -113,6 +115,7 @@ pub fn analyze(
                         field_annot: Some(
                             r#"#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]"#.into(),
                         ),
+                        docstr: member_doc,
                     })
                 } else if rust_type.starts_with("Vec") {
                     members.push(OutputMember {
@@ -121,12 +124,14 @@ pub fn analyze(
                         field_annot: Some(
                             r#"#[serde(default, skip_serializing_if = "Vec::is_empty")]"#.into(),
                         ),
+                        docstr: member_doc,
                     })
                 } else {
                     members.push(OutputMember {
                         type_: format!("Option<{}>", rust_type),
                         name: key.to_string(),
                         field_annot: None,
+                        docstr: member_doc,
                     })
                 }
             }
@@ -136,6 +141,7 @@ pub fn analyze(
             name: stack.to_string(),
             members,
             level,
+            docstr: schema.description,
         });
     }
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -103,7 +103,7 @@ pub fn analyze(
                     type_: rust_type,
                     name: key.to_string(),
                     field_annot: None,
-                    docstr: member_doc,
+                    docs: member_doc,
                 })
             } else {
                 // option wrapping possibly needed if not required
@@ -115,7 +115,7 @@ pub fn analyze(
                         field_annot: Some(
                             r#"#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]"#.into(),
                         ),
-                        docstr: member_doc,
+                        docs: member_doc,
                     })
                 } else if rust_type.starts_with("Vec") {
                     members.push(OutputMember {
@@ -124,14 +124,14 @@ pub fn analyze(
                         field_annot: Some(
                             r#"#[serde(default, skip_serializing_if = "Vec::is_empty")]"#.into(),
                         ),
-                        docstr: member_doc,
+                        docs: member_doc,
                     })
                 } else {
                     members.push(OutputMember {
                         type_: format!("Option<{}>", rust_type),
                         name: key.to_string(),
                         field_annot: None,
-                        docstr: member_doc,
+                        docs: member_doc,
                     })
                 }
             }
@@ -141,7 +141,7 @@ pub fn analyze(
             name: stack.to_string(),
             members,
             level,
-            docstr: schema.description,
+            docs: schema.description,
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub struct OutputStruct {
     pub name: String,
     pub level: u8,
     pub members: Vec<OutputMember>,
+    pub docstr: Option<String>,
 }
 
 /// Output member belonging to an OutputStruct
@@ -15,6 +16,7 @@ pub struct OutputMember {
     pub name: String,
     pub type_: String,
     pub field_annot: Option<String>,
+    pub docstr: Option<String>,
 }
 
 impl OutputStruct {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub struct OutputStruct {
     pub name: String,
     pub level: u8,
     pub members: Vec<OutputMember>,
-    pub docstr: Option<String>,
+    pub docs: Option<String>,
 }
 
 /// Output member belonging to an OutputStruct
@@ -16,7 +16,7 @@ pub struct OutputMember {
     pub name: String,
     pub type_: String,
     pub field_annot: Option<String>,
-    pub docstr: Option<String>,
+    pub docs: Option<String>,
 }
 
 impl OutputStruct {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ struct Kopium {
     api_version: Option<String>,
     #[structopt(about = "Do not emit prelude", long)]
     hide_prelude: bool,
+    #[structopt(about = "Emit docstrings from descriptions", long)]
+    docs: bool,
     #[structopt(
         about = "Derive these extra traits on generated structs",
         long,
@@ -54,20 +56,20 @@ async fn main() -> Result<()> {
     let group = crd.spec.group;
     let scope = crd.spec.scope;
 
-
     if let Some(schema) = data {
-        let mut results = vec![];
+        let mut structs = vec![];
         log::debug!("schema: {}", serde_json::to_string_pretty(&schema)?);
-        analyze(schema, "", &kind, 0, &mut results)?;
+        analyze(schema, "", &kind, 0, &mut structs)?;
 
         if !kopium.hide_prelude {
-            print_prelude(&results);
+            print_prelude(&structs);
         }
 
-        for s in results {
+        for s in structs {
             if s.level == 0 {
                 continue; // ignoring root struct
             } else {
+                print_docstr(&kopium, s.docstr, "");
                 if s.level == 1 && s.name.ends_with("Spec") {
                     print_derives(&kopium.derive);
                     println!(
@@ -87,6 +89,7 @@ async fn main() -> Result<()> {
                     println!("pub struct {} {{", spec_trimmed_name);
                 }
                 for m in s.members {
+                    print_docstr(&kopium, m.docstr, "    ");
                     if let Some(annot) = m.field_annot {
                         println!("    {}", annot);
                     }
@@ -98,7 +101,8 @@ async fn main() -> Result<()> {
                     let spec_trimmed_type = m.type_.as_str().replace(&format!("{}Spec", kind), &kind);
                     println!("    pub {}: {},", safe_name, spec_trimmed_type);
                 }
-                println!("}}")
+                println!("}}");
+                println!();
             }
         }
     } else {
@@ -106,6 +110,16 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_docstr(args: &Kopium, doc: Option<String>, indent: &str) {
+    // print doc strings if requested in arguments
+    if args.docs {
+        if let Some(d) = doc {
+            println!("{}/// {}", indent, d);
+            // TODO: logic to split doc strings by sentence / length here
+        }
+    }
 }
 
 fn print_prelude(results: &[OutputStruct]) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ struct Kopium {
     api_version: Option<String>,
     #[structopt(about = "Do not emit prelude", long)]
     hide_prelude: bool,
-    #[structopt(about = "Emit docstrings from descriptions", long)]
+    #[structopt(about = "Emit doc comments from descriptions", long)]
     docs: bool,
     #[structopt(
         about = "Derive these extra traits on generated structs",
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
             if s.level == 0 {
                 continue; // ignoring root struct
             } else {
-                print_docstr(&kopium, s.docstr, "");
+                print_docstr(&kopium, s.docs, "");
                 if s.level == 1 && s.name.ends_with("Spec") {
                     print_derives(&kopium.derive);
                     println!(
@@ -89,7 +89,7 @@ async fn main() -> Result<()> {
                     println!("pub struct {} {{", spec_trimmed_name);
                 }
                 for m in s.members {
-                    print_docstr(&kopium, m.docstr, "    ");
+                    print_docstr(&kopium, m.docs, "    ");
                     if let Some(annot) = m.field_annot {
                         println!("    {}", annot);
                     }


### PR DESCRIPTION
Pretty basic, so did this plus revamped the docs a bit.

The doc string output is not super (one giant line) so will open a follow-up issue for anyone interested about finding a smart way to split docstrings.