### PR TITLE
select version by priority rather than picking first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,18 @@ jobs:
           version: v1.21
           k3d-name: kube
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
       - run: cargo build --bin kopium
+      # Test a reasonably complicated CRD; promethesurules
+      - run: kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
       - run: cargo run --bin kopium -- prometheusrules.monitoring.coreos.com > tests/gen.rs
       - run: echo "pub type CR = PrometheusRule;" >> tests/gen.rs
       - run: kubectl apply -f tests/pr.yaml
+      - run: cargo test --test runner -- --nocapture
+      # Test a fake CRD with multiple versions
+      - run: kubectl apply -f tests/mv-crd.yaml
+      - run: cargo run --bin kopium -- multiversions.clux.dev > tests/gen.rs
+      - run: echo "pub type CR = MultiVersion;" >> tests/gen.rs
+      - run: kubectl apply -f tests/mv.yaml
       - run: cargo test --test runner -- --nocapture
 
   rustfmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +527,7 @@ dependencies = [
  "env_logger",
  "k8s-openapi",
  "kube",
+ "kube-core 0.65.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "quote",
  "serde",
@@ -531,21 +538,19 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dcc2f8ca3f2427a72acc31fa9538159f6b33a97002e315a3fcd5323cf51a2b"
+version = "0.65.0"
+source = "git+https://github.com/kube-rs/kube-rs.git?branch=master#4017a3f349e5901923422c6abece985c513e486f"
 dependencies = [
  "k8s-openapi",
  "kube-client",
- "kube-core",
+ "kube-core 0.65.0 (git+https://github.com/kube-rs/kube-rs.git?branch=master)",
  "kube-derive",
 ]
 
 [[package]]
 name = "kube-client"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8957106140aa24a76de3f7d005966f381b30a4cd6a9c003b3bba6828e9617535"
+version = "0.65.0"
+source = "git+https://github.com/kube-rs/kube-rs.git?branch=master#4017a3f349e5901923422c6abece985c513e486f"
 dependencies = [
  "base64",
  "bytes",
@@ -560,7 +565,7 @@ dependencies = [
  "hyper-tls",
  "jsonpath_lib",
  "k8s-openapi",
- "kube-core",
+ "kube-core 0.65.0 (git+https://github.com/kube-rs/kube-rs.git?branch=master)",
  "openssl",
  "pem",
  "pin-project",
@@ -578,9 +583,24 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.64.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec73e7d8e937dd055d962af06e635e262fdb6ed341c36ecf659d4fece0a8005"
+checksum = "c52b6ab05d160691083430f6f431707a4e05b64903f2ffa0095ee5efde759117"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http",
+ "k8s-openapi",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.65.0"
+source = "git+https://github.com/kube-rs/kube-rs.git?branch=master#4017a3f349e5901923422c6abece985c513e486f"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -594,9 +614,8 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6651bfae82bc23439da1099174b52bcbf68df065dc33317c912e3c5c5cea43c"
+version = "0.65.0"
+source = "git+https://github.com/kube-rs/kube-rs.git?branch=master#4017a3f349e5901923422c6abece985c513e486f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1331,17 +1350,19 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f70061b0592867f0a60e67a6e699da5fe000c88a360a5b92ebdba9d73b2238c"
+checksum = "39ee603d6e665ecc7e0f8d479eedb4626bd4726f0ee6119cee5b3a6bf184cac0"
 dependencies = [
  "base64",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
- "pin-project",
+ "http-range-header",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "darling"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
 dependencies = [
  "fnv",
  "ident_case",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
  "darling_core",
  "quote",
@@ -179,6 +179,12 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "either"
@@ -527,7 +533,7 @@ dependencies = [
  "env_logger",
  "k8s-openapi",
  "kube",
- "kube-core 0.65.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kube-core 0.65.0",
  "log",
  "quote",
  "serde",
@@ -538,19 +544,21 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.65.0"
-source = "git+https://github.com/kube-rs/kube-rs.git?branch=master#4017a3f349e5901923422c6abece985c513e486f"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b96944d327b752df4f62f3a31d8694892af06fb585747c0b5e664927823d1a"
 dependencies = [
  "k8s-openapi",
  "kube-client",
- "kube-core 0.65.0 (git+https://github.com/kube-rs/kube-rs.git?branch=master)",
+ "kube-core 0.66.0",
  "kube-derive",
 ]
 
 [[package]]
 name = "kube-client"
-version = "0.65.0"
-source = "git+https://github.com/kube-rs/kube-rs.git?branch=master#4017a3f349e5901923422c6abece985c513e486f"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232db1af3d3680f9289cf0b4db51b2b9fee22550fc65d25869e39b23e0aaa696"
 dependencies = [
  "base64",
  "bytes",
@@ -565,10 +573,11 @@ dependencies = [
  "hyper-tls",
  "jsonpath_lib",
  "k8s-openapi",
- "kube-core 0.65.0 (git+https://github.com/kube-rs/kube-rs.git?branch=master)",
+ "kube-core 0.66.0",
  "openssl",
  "pem",
  "pin-project",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -599,14 +608,16 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.65.0"
-source = "git+https://github.com/kube-rs/kube-rs.git?branch=master#4017a3f349e5901923422c6abece985c513e486f"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de491f8c9ee97117e0b47a629753e939c2392d5d0a40f6928e582a5fba328098"
 dependencies = [
  "chrono",
  "form_urlencoded",
  "http",
  "k8s-openapi",
  "once_cell",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror",
@@ -614,8 +625,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.65.0"
-source = "git+https://github.com/kube-rs/kube-rs.git?branch=master#4017a3f349e5901923422c6abece985c513e486f"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbb86bb3607245a67c8ad3a52aff41108f36b0d1e9e3e82ffb5760bfd84b965"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1028,10 +1040,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b5a3c80cea1ab61f4260238409510e814e38b4b563c06044edf91e7dc070e3"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ae4dce13e8614c46ac3c38ef1c0d668b101df6ac39817aebdaa26642ddae9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -1080,6 +1126,17 @@ name = "serde_derive"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1537,3 +1594,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ structopt = "0.3"
 kube-core = "0.65.0"
 
 [dependencies.kube]
-#version = "0.66.0"
-git = "https://github.com/kube-rs/kube-rs.git"
-branch = "master"
+version = "0.66.0"
+#git = "https://github.com/kube-rs/kube-rs.git"
+#branch = "master"
 features = ["derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ name = "kopium"
 path = "src/lib.rs"
 
 [dependencies]
-kube = { version = "0.64.0", features = ["derive"] }
 k8s-openapi = { version = "0.13.1", features = ["v1_22"] }
 tokio = { version = "1.14.0", features = ["full"] }
 anyhow = "1.0.48"
@@ -33,3 +32,10 @@ clap = "2.33"
 quote = "1.0.10"
 serde = { version = "1.0.130", features = ["derive"] }
 structopt = "0.3"
+kube-core = "0.65.0"
+
+[dependencies.kube]
+#version = "0.66.0"
+git = "https://github.com/kube-rs/kube-rs.git"
+branch = "master"
+features = ["derive"]

--- a/tests/mv-crd.yaml
+++ b/tests/mv-crd.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: multiversions.clux.dev
+spec:
+  group: clux.dev
+  names:
+    categories: []
+    kind: MultiVersion
+    plural: multiversions
+    shortNames: []
+    singular: multiversion
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns: []
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+              type: object
+          required:
+            - spec
+          title: MVV
+          type: object
+      served: true
+      storage: true
+    - additionalPrinterColumns: []
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+              type: object
+          required:
+            - spec
+          title: MVV
+          type: object
+      served: true
+      storage: false

--- a/tests/mv.yaml
+++ b/tests/mv.yaml
@@ -1,0 +1,6 @@
+apiVersion: clux.dev/v1
+kind: MultiVersion
+metadata:
+  name: gen
+spec:
+  name: hello


### PR DESCRIPTION
uses master version of kube for this with the newly merged `kube::core::Version` add (will be avialable in 0.66.0)

only did the basics here of linking up the feature we did in https://github.com/kube-rs/kube-rs/pull/764

we still need some way of testing this - and haven't gotten a crd to test out multi version atm.

replaces #24 for #23 - but needs some way of testing it. @imp if you are free - some review / future help here would be great.

if not, i'll pick this up at some point over the new year - and enjoy the end of your year :-)