### PR TITLE
improve testing experience with a justfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - uses: extractions/setup-just@v1
       - uses: actions-rs/toolchain@v1
         with:
           override: true
@@ -24,23 +25,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo build --bin kopium
       # Test a reasonably complicated CRD; promethesurules
-      - run: kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-      - run: cargo run --bin kopium -- prometheusrules.monitoring.coreos.com > tests/gen.rs
-      - run: echo "pub type CR = PrometheusRule;" >> tests/gen.rs
-      - run: kubectl apply -f tests/pr.yaml
-      - run: cargo test --test runner -- --nocapture
+      - run: just test-pr
       # Test a fake CRD with multiple versions
-      - run: kubectl apply -f tests/mv-crd.yaml
-      - run: cargo run --bin kopium -- multiversions.clux.dev > tests/gen.rs
-      - run: echo "pub type CR = MultiVersion;" >> tests/gen.rs
-      - run: kubectl apply -f tests/mv.yaml
-      - run: cargo test --test runner -- --nocapture
+      - run: just test-mv
       # Test argocd Applicaiton
-      - run: kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/crds/application-crd.yaml
-      - run: cargo run --bin kopium -- applications.argoproj.io > tests/gen.rs
-      - run: echo "pub type CR = Application;" >> tests/gen.rs
-      - run: kubectl apply -f tests/app.yaml
-      - run: cargo test --test runner -- --nocapture
+      - run: just test-argo
 
   rustfmt:
     name: Run rustfmt

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ kubectl apply -f tests/pr.yaml # needs to contain a CR with name "gen"
 cargo test --test runner -- --nocapture
 ```
 
+test shortcuts available via `just` in the [`justfile`](./justfile).
+
 ## License
 
 Apache 2.0 licensed. See LICENSE for details.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,30 @@
+NAME := "kopium"
+REPO := "kube-rs"
+VERSION := `git rev-parse HEAD`
+SEMVER_VERSION := `grep version Cargo.toml | awk -F"\"" '{print $2}' | head -n 1`
+
+default:
+  @just --list --unsorted | grep -v "    default"
+
+test: test-pr test-mv test-argo
+
+test-pr:
+  kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+  cargo run --bin kopium -- prometheusrules.monitoring.coreos.com > tests/gen.rs
+  echo "pub type CR = PrometheusRule;" >> tests/gen.rs
+  kubectl apply -f tests/pr.yaml
+  cargo test --test runner -- --nocapture
+
+test-mv:
+  kubectl apply -f tests/mv-crd.yaml
+  cargo run --bin kopium -- multiversions.clux.dev > tests/gen.rs
+  echo "pub type CR = MultiVersion;" >> tests/gen.rs
+  kubectl apply -f tests/mv.yaml
+  cargo test --test runner -- --nocapture
+
+test-argo:
+  kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/crds/application-crd.yaml
+  cargo run --bin kopium -- applications.argoproj.io > tests/gen.rs
+  echo "pub type CR = Application;" >> tests/gen.rs
+  kubectl apply -f tests/app.yaml
+  cargo test --test runner -- --nocapture

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,6 @@ impl Kopium {
 
 
 fn print_prelude(results: &[OutputStruct]) {
-    println!("#![allow(non_snake_case)]"); // see https://github.com/kube-rs/kopium/issues/22
     println!("use kube::CustomResource;");
     println!("use serde::{{Serialize, Deserialize}};");
     if results.iter().any(|o| o.uses_btreemaps()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,6 +191,7 @@ impl Kopium {
 
 
 fn print_prelude(results: &[OutputStruct]) {
+    println!("#![allow(non_snake_case)]"); // see https://github.com/kube-rs/kopium/issues/22
     println!("use kube::CustomResource;");
     println!("use serde::{{Serialize, Deserialize}};");
     if results.iter().any(|o| o.uses_btreemaps()) {


### PR DESCRIPTION
originally tried to do a thing related to #22 here, but that has been reverted:

- cannot do module level attributes because we don't know how users will consume the generated file.

for example, the tests uses `include!` and that means the module level
macro will not actually be at the top of the file.

also don't really want to selectively add to all structs, let's just solve #22 properly.

instead have improved the testing experience a bit.