### PR TITLE
Handle optional Vec and BTreeMap as Option<t>

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Requirements:
 ## Features
 
 - **Instantly queryable**: generated type uses [`kube-derive`](https://docs.rs/kube/latest/kube/derive.CustomResource.html) to provide api integration with `kube`
-- **Ergonomic Rust types**: `#[serde(default)]` on `Vec`/`BTreeMap` over `Option` wrapping
 - **[Rust doc comments](https://doc.rust-lang.org/rust-by-example/meta/doc.html#doc-comments)**: optionally extracted from `description` values in schema (`--docs`)
 
 ## Installation
@@ -48,15 +47,17 @@ use std::collections::BTreeMap;
 #[kube(schema = "disabled")]
 pub struct PrometheusRuleSpec {
     /// Content of Prometheus rule file
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub groups: Vec<PrometheusRuleGroups>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<PrometheusRuleGroups>>,
 }
 
-/// RuleGroup is a list of sequentially evaluated recording and alerting rules. Note: PartialResponseStrategy is only used by ThanosRuler and will be ignored by Prometheus instances.  Valid values for this field are 'warn' or 'abort'.  More info: https://github.com/thanos-io/thanos/blob/master/docs/components/rule.md#partial-response
+/// RuleGroup is a list of sequentially evaluated recording and alerting rules. Note: PartialResponseStrategy is only used by ThanosRuler and will be ignored by Prometheus instances.  Valid values for this field are 'warn' or 'abort'.  More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PrometheusRuleGroups {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interval: Option<String>,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub partial_response_strategy: Option<String>,
     pub rules: Vec<PrometheusRuleGroupsRules>,
 }
@@ -64,13 +65,16 @@ pub struct PrometheusRuleGroups {
 /// Rule describes an alerting or recording rule See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) or [recording](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules) rule
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PrometheusRuleGroupsRules {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alert: Option<String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub annotations: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<BTreeMap<String, String>>,
     pub expr: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub r#for: Option<String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub labels: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<BTreeMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub record: Option<String>,
 }
 ```

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -210,32 +210,14 @@ fn analyze_object_properties(
                 docs: member_doc,
             })
         } else {
-            // option wrapping possibly needed if not required
+            // option wrapping needed if not required
             debug!("with optional member {} of type {}", key, rust_type);
-            if rust_type.starts_with("BTreeMap") {
-                members.push(OutputMember {
-                    type_: rust_type,
-                    name: key.to_string(),
-                    field_annot: Some(
-                        r#"#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]"#.into(),
-                    ),
-                    docs: member_doc,
-                })
-            } else if rust_type.starts_with("Vec") {
-                members.push(OutputMember {
-                    type_: rust_type,
-                    name: key.to_string(),
-                    field_annot: Some(r#"#[serde(default, skip_serializing_if = "Vec::is_empty")]"#.into()),
-                    docs: member_doc,
-                })
-            } else {
-                members.push(OutputMember {
-                    type_: format!("Option<{}>", rust_type),
-                    name: key.to_string(),
-                    field_annot: None,
-                    docs: member_doc,
-                })
-            }
+            members.push(OutputMember {
+                type_: format!("Option<{}>", rust_type),
+                name: key.to_string(),
+                field_annot: Some(r#"#[serde(default, skip_serializing_if = "Option::is_none")]"#.into()),
+                docs: member_doc,
+            })
         }
     }
     results.push(OutputStruct {


### PR DESCRIPTION
Previously, optional array properties are required in the generated struct, but skipped if serializing. This is incorrect behavior, since an empty Vec is not the same as not supplying a Vec.

This breaks server-side apply-ing new resources to remove things from the Vec, as well as cases where a property is required in a one-of, but you actually want to send the empty Vec as one of those properties.

This change instead makes it an Option<Vec<T>> with #[serde(default, skip_serializing_if = "Option::is_none")].

The above also applies to BTreeMaps.

Resolves https://github.com/kube-rs/kopium/issues/40