### PR TITLE
use BTreeMap for empty objects with preserve-unknown-fields

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ default:
 fmt:
   cargo +nightly fmt
 
-test: test-pr test-mv test-argo test-agent test-certmanager test-cluster
+test: test-pr test-mv test-argo test-agent test-certmanager test-cluster test-linkerd-serverauth
 
 test-pr:
   kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
@@ -52,6 +52,22 @@ test-cluster:
   echo "pub type CR = Cluster;" >> tests/gen.rs
   # No test instance for this crd
   cargo build --test runner
+
+test-linkerd-serverauth:
+  kubectl apply --server-side -f tests/serverauth-crd.yaml
+  cargo run --bin kopium -- --docs serverauthorizations.policy.linkerd.io > tests/gen.rs
+  echo "pub type CR = ServerAuthorization;" >> tests/gen.rs
+  kubectl apply -f tests/serverauth.yaml
+  cargo test --test runner -- --nocapture
+
+# This fails in the test runner when trying to patch the applied instance.
+# let _obj = cr.patch_status("gen", &pp, &patch).await?;
+#test-linkerd-server:
+#  kubectl apply --server-side -f tests/server-crd.yaml
+#  cargo run --bin kopium -- --docs servers.policy.linkerd.io > tests/gen.rs
+#  echo "pub type CR = Server;" >> tests/gen.rs
+#  kubectl apply -f tests/server.yaml
+#  cargo test --test runner -- --nocapture
 
 release:
   cargo release minor --execute

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ default:
 fmt:
   cargo +nightly fmt
 
-test: test-pr test-mv test-argo test-agent test-certmanager test-cluster test-linkerd-serverauth
+test: test-pr test-mv test-argo test-agent test-certmanager test-cluster test-linkerd-serverauth test-linkerd-server
 
 test-pr:
   kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
@@ -60,14 +60,12 @@ test-linkerd-serverauth:
   kubectl apply -f tests/serverauth.yaml
   cargo test --test runner -- --nocapture
 
-# This fails in the test runner when trying to patch the applied instance.
-# let _obj = cr.patch_status("gen", &pp, &patch).await?;
-#test-linkerd-server:
-#  kubectl apply --server-side -f tests/server-crd.yaml
-#  cargo run --bin kopium -- --docs servers.policy.linkerd.io > tests/gen.rs
-#  echo "pub type CR = Server;" >> tests/gen.rs
-#  kubectl apply -f tests/server.yaml
-#  cargo test --test runner -- --nocapture
+test-linkerd-server:
+  kubectl apply --server-side -f tests/server-crd.yaml
+  cargo run --bin kopium -- --docs servers.policy.linkerd.io > tests/gen.rs
+  echo "pub type CR = Server;" >> tests/gen.rs
+  kubectl apply -f tests/server.yaml
+  cargo test --test runner -- --nocapture
 
 release:
   cargo release minor --execute

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -437,7 +437,9 @@ type: object
         let match_labels = &server_selector.members[0];
         assert_eq!(match_labels.name, "matchLabels");
         assert_eq!(match_labels.type_, "BTreeMap<String, serde_json::Value>");
+    }
 
+    #[test]
     fn int_or_string() {
         let schema_str = r#"
             properties:

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -46,6 +46,10 @@ pub fn analyze(
             // else, regular properties only
             debug!("Generating struct for {} (under {})", current, stack);
             // initial analysis of properties (we do not recurse here, we need to find members first)
+            if props.is_empty() && schema.x_kubernetes_preserve_unknown_fields.unwrap_or(false) {
+                warn!("not generating type {} - using BTreeMap", current);
+                return Ok(());
+            }
             let new_result =
                 analyze_object_properties(&props, stack, &mut array_recurse_level, level, &schema)?;
             results.extend(new_result);
@@ -166,6 +170,10 @@ fn analyze_object_properties(
                             x => Some(uppercase_first_letter(x)), // best guess
                         };
                     }
+                } else if value.properties.is_none()
+                    && value.x_kubernetes_preserve_unknown_fields.unwrap_or(false)
+                {
+                    dict_key = Some("serde_json::Value".into());
                 }
                 if let Some(dict) = dict_key {
                     format!("BTreeMap<String, {}>", dict)
@@ -332,7 +340,6 @@ fn uppercase_first_letter(s: &str) -> String {
     }
 }
 
-
 // unit tests particular schema patterns
 #[cfg(test)]
 mod test {
@@ -392,5 +399,45 @@ mod test {
         assert_eq!(other.members[1].type_, "String");
         assert_eq!(other.members[2].name, "status");
         assert_eq!(other.members[2].type_, "String");
+    }
+
+    #[test]
+    fn empty_preserve_unknown_fields() {
+        let schema_str = r#"
+description: |-
+  Identifies servers in the same namespace for which this authorization applies.
+required:
+  - selector
+properties:
+  selector:
+    description: A label query over servers on which this authorization
+      applies.
+    required:
+      - matchLabels
+    properties:
+      matchLabels:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    type: object
+type: object
+"#;
+        let schema: JSONSchemaProps = serde_yaml::from_str(schema_str).unwrap();
+        println!("{:#?}", schema);
+        let mut structs = vec![];
+        analyze(schema, "Selector", "Server", 0, &mut structs).unwrap();
+        println!("{:#?}", structs);
+
+        let root = &structs[0];
+        assert_eq!(root.name, "Server");
+        assert_eq!(root.level, 0);
+        let root_member = &root.members[0];
+        assert_eq!(root_member.name, "selector");
+        assert_eq!(root_member.type_, "ServerSelector");
+        let server_selector = &structs[1];
+        assert_eq!(server_selector.name, "ServerSelector");
+        assert_eq!(server_selector.level, 1);
+        let match_labels = &server_selector.members[0];
+        assert_eq!(match_labels.name, "matchLabels");
+        assert_eq!(match_labels.type_, "BTreeMap<String, serde_json::Value>");
     }
 }

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -39,12 +39,17 @@ mod tests {
         if let Ok(contents) = std::fs::read_to_string(&filename) {
             let file_data: serde_yaml::Value = serde_yaml::from_str(&contents).expect("read yaml");
             let data: serde_json::Value = serde_json::to_value(&file_data).expect("to json");
-            let patch = Patch::Merge(data);
+            if let Some(root) = data.as_object() {
+                if root.contains_key("status") {
+                    println!("Patching status");
+                    let patch = Patch::Merge(data);
 
-            let pp = PatchParams::default();
-            let _obj = cr.patch_status("gen", &pp, &patch).await?;
-            // TODO: need some generic way to detect if we can use status..
-            //assert_eq!(obj.status.is_some());
+                    let pp = PatchParams::default();
+                    let _obj = cr.patch_status("gen", &pp, &patch).await?;
+                    // TODO: need some generic way to detect if we can use status..
+                    //assert_eq!(obj.status.is_some());
+                }
+            }
         }
         Ok(())
     }

--- a/tests/server-crd.yaml
+++ b/tests/server-crd.yaml
@@ -152,24 +152,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: Server
-    listKind: ServerList
-    plural: servers
-    shortNames:
-    - srv
-    singular: server
-  conditions:
-  - lastTransitionTime: "2021-12-13T21:51:27Z"
-    message: no conflicts found
-    reason: NoConflicts
-    status: "True"
-    type: NamesAccepted
-  - lastTransitionTime: "2021-12-13T21:51:27Z"
-    message: the initial names have been accepted
-    reason: InitialNamesAccepted
-    status: "True"
-    type: Established
-  storedVersions:
-  - v1beta1

--- a/tests/server-crd.yaml
+++ b/tests/server-crd.yaml
@@ -1,0 +1,175 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servers.policy.linkerd.io
+spec:
+  conversion:
+    strategy: None
+  group: policy.linkerd.io
+  names:
+    kind: Server
+    listKind: ServerList
+    plural: servers
+    shortNames:
+    - srv
+    singular: server
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              podSelector:
+                description: Selects pods in the same namespace.
+                oneOf:
+                - required:
+                  - matchExpressions
+                - required:
+                  - matchLabels
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              port:
+                description: A port name or number. Must exist in a pod spec.
+                x-kubernetes-int-or-string: true
+              proxyProtocol:
+                default: unknown
+                description: |-
+                  Configures protocol discovery for inbound connections.
+                  Supersedes the `config.linkerd.io/opaque-ports` annotation.
+                enum:
+                - unknown
+                - HTTP/1
+                - HTTP/2
+                - gRPC
+                - opaque
+                - TLS
+                type: string
+            required:
+            - podSelector
+            - port
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+  - additionalPrinterColumns:
+    - description: The port the server is listening on
+      jsonPath: .spec.port
+      name: Port
+      type: string
+    - description: The protocol of the server
+      jsonPath: .spec.proxyProtocol
+      name: Protocol
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              podSelector:
+                description: Selects pods in the same namespace.
+                oneOf:
+                - required:
+                  - matchExpressions
+                - required:
+                  - matchLabels
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              port:
+                description: A port name or number. Must exist in a pod spec.
+                x-kubernetes-int-or-string: true
+              proxyProtocol:
+                default: unknown
+                description: |-
+                  Configures protocol discovery for inbound connections.
+                  Supersedes the `config.linkerd.io/opaque-ports` annotation.
+                enum:
+                - unknown
+                - HTTP/1
+                - HTTP/2
+                - gRPC
+                - opaque
+                - TLS
+                type: string
+            required:
+            - podSelector
+            - port
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: Server
+    listKind: ServerList
+    plural: servers
+    shortNames:
+    - srv
+    singular: server
+  conditions:
+  - lastTransitionTime: "2021-12-13T21:51:27Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2021-12-13T21:51:27Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1beta1

--- a/tests/server.yaml
+++ b/tests/server.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy.linkerd.io/v1beta1
+kind: Server
+metadata:
+  name: gen
+spec:
+  podSelector:
+    matchLabels: {}
+  port: myport
+  proxyProtocol: HTTP/1

--- a/tests/serverauth-crd.yaml
+++ b/tests/serverauth-crd.yaml
@@ -288,24 +288,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ServerAuthorization
-    listKind: ServerAuthorizationList
-    plural: serverauthorizations
-    shortNames:
-    - saz
-    singular: serverauthorization
-  conditions:
-  - lastTransitionTime: "2021-12-13T21:51:27Z"
-    message: no conflicts found
-    reason: NoConflicts
-    status: "True"
-    type: NamesAccepted
-  - lastTransitionTime: "2021-12-13T21:51:27Z"
-    message: the initial names have been accepted
-    reason: InitialNamesAccepted
-    status: "True"
-    type: Established
-  storedVersions:
-  - v1beta1

--- a/tests/serverauth-crd.yaml
+++ b/tests/serverauth-crd.yaml
@@ -1,0 +1,311 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serverauthorizations.policy.linkerd.io
+spec:
+  conversion:
+    strategy: None
+  group: policy.linkerd.io
+  names:
+    kind: ServerAuthorization
+    listKind: ServerAuthorizationList
+    plural: serverauthorizations
+    shortNames:
+    - saz
+    singular: serverauthorization
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: Authorizes clients to communicate with Linkerd-proxied servers.
+            properties:
+              client:
+                description: Describes clients authorized to access a server.
+                oneOf:
+                - required:
+                  - meshTLS
+                - required:
+                  - unauthenticated
+                properties:
+                  meshTLS:
+                    oneOf:
+                    - required:
+                      - unauthenticatedTLS
+                    - required:
+                      - identities
+                    - required:
+                      - serviceAccounts
+                    properties:
+                      identities:
+                        description: |-
+                          Authorizes clients with the provided proxy identity strings (as provided via MTLS)
+                          The `*` prefix can be used to match all identities in a domain. An identity string of `*` indicates that all authentication clients are authorized.
+                        items:
+                          pattern: ^(\*|[a-z0-9]([-a-z0-9]*[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type: array
+                      serviceAccounts:
+                        description: Authorizes clients with the provided proxy identity
+                          service accounts (as provided via MTLS)
+                        items:
+                          properties:
+                            name:
+                              description: The ServiceAccount's name.
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            namespace:
+                              description: The ServiceAccount's namespace. If unset,
+                                the authorization's namespace is used.
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      unauthenticatedTLS:
+                        description: |-
+                          Indicates that no client identity is required for communication.
+                          This is mostly important for the identity controller, which must terminate TLS connections from clients that do not yet have a certificate.
+                        type: boolean
+                    type: object
+                  networks:
+                    description: Limits the client IP addresses to which this authorization
+                      applies. If unset, the server chooses a default (typically,
+                      all IPs or the cluster's pod network).
+                    items:
+                      properties:
+                        cidr:
+                          type: string
+                        except:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                  unauthenticated:
+                    description: Authorizes unauthenticated clients to access a server.
+                    type: boolean
+                type: object
+              server:
+                description: |-
+                  Identifies servers in the same namespace for which this authorization applies.
+                  Only one of `name` or `selector` may be specified.
+                oneOf:
+                - required:
+                  - name
+                - required:
+                  - selector
+                properties:
+                  name:
+                    description: References a `Server` instance by name
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  selector:
+                    description: A label query over servers on which this authorization
+                      applies.
+                    oneOf:
+                    - required:
+                      - matchLabels
+                    - required:
+                      - matchExpressions
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                type: object
+            required:
+            - server
+            - client
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+  - additionalPrinterColumns:
+    - description: The server that this grants access to
+      jsonPath: .spec.server.name
+      name: Server
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: Authorizes clients to communicate with Linkerd-proxied servers.
+            properties:
+              client:
+                description: Describes clients authorized to access a server.
+                oneOf:
+                - required:
+                  - meshTLS
+                - required:
+                  - unauthenticated
+                properties:
+                  meshTLS:
+                    oneOf:
+                    - required:
+                      - unauthenticatedTLS
+                    - required:
+                      - identities
+                    - required:
+                      - serviceAccounts
+                    properties:
+                      identities:
+                        description: |-
+                          Authorizes clients with the provided proxy identity strings (as provided via MTLS)
+                          The `*` prefix can be used to match all identities in a domain. An identity string of `*` indicates that all authentication clients are authorized.
+                        items:
+                          pattern: ^(\*|[a-z0-9]([-a-z0-9]*[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type: array
+                      serviceAccounts:
+                        description: Authorizes clients with the provided proxy identity
+                          service accounts (as provided via MTLS)
+                        items:
+                          properties:
+                            name:
+                              description: The ServiceAccount's name.
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            namespace:
+                              description: The ServiceAccount's namespace. If unset,
+                                the authorization's namespace is used.
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      unauthenticatedTLS:
+                        description: |-
+                          Indicates that no client identity is required for communication.
+                          This is mostly important for the identity controller, which must terminate TLS connections from clients that do not yet have a certificate.
+                        type: boolean
+                    type: object
+                  networks:
+                    description: Limits the client IP addresses to which this authorization
+                      applies. If unset, the server chooses a default (typically,
+                      all IPs or the cluster's pod network).
+                    items:
+                      properties:
+                        cidr:
+                          type: string
+                        except:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                  unauthenticated:
+                    description: Authorizes unauthenticated clients to access a server.
+                    type: boolean
+                type: object
+              server:
+                description: |-
+                  Identifies servers in the same namespace for which this authorization applies.
+                  Only one of `name` or `selector` may be specified.
+                oneOf:
+                - required:
+                  - name
+                - required:
+                  - selector
+                properties:
+                  name:
+                    description: References a `Server` instance by name
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  selector:
+                    description: A label query over servers on which this authorization
+                      applies.
+                    oneOf:
+                    - required:
+                      - matchLabels
+                    - required:
+                      - matchExpressions
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                type: object
+            required:
+            - server
+            - client
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ServerAuthorization
+    listKind: ServerAuthorizationList
+    plural: serverauthorizations
+    shortNames:
+    - saz
+    singular: serverauthorization
+  conditions:
+  - lastTransitionTime: "2021-12-13T21:51:27Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2021-12-13T21:51:27Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1beta1

--- a/tests/serverauth.yaml
+++ b/tests/serverauth.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy.linkerd.io/v1beta1
+kind: ServerAuthorization
+metadata:
+  name: gen
+spec:
+  client:
+    meshTLS:
+      identities:
+      - '*.environment-0d0c8465-02ef-496c-9586-ebbaecd63e0d-0.serviceaccount.identity.linkerd.cluster.local'
+  server:
+    name: myserver


### PR DESCRIPTION
If the object is empty and it has s-kubernetes-preserve-unknown-fields
set, do not create an empty struct.
Instead, use a `BTreeMap<String, serde_json::Value>`.