### PR TITLE
Add optional snake_case conversion of member names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +539,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
+ "heck 0.4.0",
  "k8s-openapi",
  "kube",
  "log",
@@ -1165,7 +1172,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ quote = "1.0.10"
 serde = { version = "1.0.130", features = ["derive"] }
 structopt = "0.3"
 serde_yaml = "0.8.23"
+heck = "0.4.0"
 
 [dependencies.kube]
 version = "0.69.0"


### PR DESCRIPTION
Using heck as it's the most popular libary out there (plus it's
maintained by boats).

This CAN lead to some subtle behaviour due to how serde's r`ename_all` is **not** a true inverse of `ToSnakeCase`, but I believe this can be rectified for those cases with some extra override flags (awkward tho it may be).

fixes #22