### PR TITLE
Add simple enum support

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ test-pr:
 
 test-sm:
   kubectl apply --force-conflicts --server-side -f tests/servicemon-crd.yaml
-  cargo run --bin kopium -- -izf tests/servicemon-crd.yaml > tests/gen.rs
+  cargo run --bin kopium -- -izdf tests/servicemon-crd.yaml > tests/gen.rs
   echo "pub type CR = ServiceMonitor;" >> tests/gen.rs
   kubectl apply -f tests/servicemon.yaml
   cargo test --test runner -- --nocapture
@@ -68,11 +68,11 @@ test-linkerd-serverauth:
   cargo test --test runner -- --nocapture
 
 test-linkerd-server:
-  kubectl apply --server-side -f tests/server-crd.yaml
-  cargo run --bin kopium -- -ibz servers.policy.linkerd.io > tests/gen.rs
-  echo "pub type CR = Server;" >> tests/gen.rs
-  kubectl apply -f tests/server.yaml
-  cargo test --test runner -- --nocapture
+  #kubectl apply --server-side -f tests/server-crd.yaml
+  #cargo run --bin kopium -- -ibz servers.policy.linkerd.io > tests/gen.rs
+  #echo "pub type CR = Server;" >> tests/gen.rs
+  #kubectl apply -f tests/server.yaml
+  #cargo test --test runner -- --nocapture
 
 test-istio-destrule:
   kubectl apply --server-side -f tests/destinationrule-crd.yaml

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -434,9 +434,20 @@ mod test {
     use crate::analyze;
     use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::JSONSchemaProps;
     use serde_yaml;
+    use std::sync::Once;
+
+    static START: Once = Once::new();
+    fn init() {
+        START.call_once(|| {
+            env_logger::init();
+        });
+    }
+    // To debug individual tests:
+    // RUST_LOG=debug cargo test --lib -- --nocapture testname
 
     #[test]
     fn map_of_struct() {
+        init();
         // validationsInfo from agent test
         let schema_str = r#"
         description: AgentStatus defines the observed state of Agent
@@ -464,7 +475,6 @@ mod test {
         type: object
 "#;
         let schema: JSONSchemaProps = serde_yaml::from_str(schema_str).unwrap();
-        //env_logger::init();
         //println!("schema: {}", serde_json::to_string_pretty(&schema).unwrap());
 
         let mut structs = vec![];
@@ -491,6 +501,7 @@ mod test {
 
     #[test]
     fn empty_preserve_unknown_fields() {
+        init();
         let schema_str = r#"
 description: |-
   Identifies servers in the same namespace for which this authorization applies.
@@ -531,6 +542,7 @@ type: object
 
     #[test]
     fn int_or_string() {
+        init();
         let schema_str = r#"
             properties:
               port:
@@ -556,6 +568,7 @@ type: object
 
     #[test]
     fn enum_string() {
+        init();
         let schema_str = r#"
       properties:
         operator:
@@ -571,7 +584,6 @@ type: object
 "#;
 
         let schema: JSONSchemaProps = serde_yaml::from_str(schema_str).unwrap();
-        //env_logger::init();
         let mut structs = vec![];
         analyze(schema, "", "MatchExpressions", 0, &mut structs).unwrap();
         println!("got {:?}", structs);
@@ -599,6 +611,7 @@ type: object
 
     #[test]
     fn enum_string_within_container() {
+        init();
         let schema_str = r#"
       description: Endpoint
       properties:
@@ -607,8 +620,6 @@ type: object
             properties:
               action:
                 default: replace
-                description: Action to perform based on regex matching.
-                  Default is 'replace'
                 enum:
                 - replace
                 - keep
@@ -627,7 +638,6 @@ type: object
         "#;
 
         let schema: JSONSchemaProps = serde_yaml::from_str(schema_str).unwrap();
-        //env_logger::init();
         let mut structs = vec![];
         analyze(schema, "", "Endpoint", 0, &mut structs).unwrap();
         println!("got {:?}", structs);
@@ -664,6 +674,7 @@ type: object
     #[test]
     #[ignore] // oneof support not done
     fn enum_oneof() {
+        init();
         let schema_str = r#"
     description: "Auto-generated derived type for ServerSpec via `CustomResource`"
     properties:
@@ -712,7 +723,6 @@ type: object
     type: object"#;
 
         let schema: JSONSchemaProps = serde_yaml::from_str(schema_str).unwrap();
-        //env_logger::init();
         let mut structs = vec![];
         analyze(schema, "", "ServerSpec", 0, &mut structs).unwrap();
         println!("got {:?}", structs);
@@ -764,6 +774,7 @@ type: object
 
     #[test]
     fn service_monitor_params() {
+        init();
         let schema_str = r#"
         properties:
           endpoints:
@@ -785,7 +796,6 @@ type: object
         type: object
 "#;
         let schema: JSONSchemaProps = serde_yaml::from_str(schema_str).unwrap();
-        //env_logger::init();
         let mut structs = vec![];
         analyze(schema, "Endpoints", "ServiceMonitor", 0, &mut structs).unwrap();
         println!("got {:?}", structs);
@@ -811,6 +821,7 @@ type: object
 
     #[test]
     fn integer_handling_in_maps() {
+        init();
         // via https://istio.io/latest/docs/reference/config/networking/destination-rule/
         // distribute:
         // - from: us-west/zone1/*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub struct OutputStruct {
     pub level: u8,
     pub members: Vec<OutputMember>,
     pub docs: Option<String>,
+    pub is_enum: bool,
 }
 
 /// Output member belonging to an OutputStruct

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,15 +271,23 @@ impl Kopium {
                                 println!(r#"#[kube(schema = "{}")]"#, self.schema);
                             }
                         }
-                        println!("pub struct {} {{", s.name);
+                        if s.is_enum {
+                            println!("pub enum {} {{", s.name);
+                        } else {
+                            println!("pub struct {} {{", s.name);
+                        }
                     } else {
                         self.print_derives(false);
                         let spec_trimmed_name = s.name.as_str().replace(&format!("{}Spec", kind), &kind);
-                        println!("pub struct {} {{", spec_trimmed_name);
+                        if s.is_enum {
+                            println!("pub enum {} {{", spec_trimmed_name);
+                        } else {
+                            println!("pub struct {} {{", spec_trimmed_name);
+                        }
                     }
                     for m in s.members {
                         self.print_docstr(m.docs, "    ");
-                        let name = if self.snake_case {
+                        let name = if self.snake_case && !s.is_enum {
                             let converted = m.name.to_snake_case();
                             if converted != m.name {
                                 println!("    #[serde(rename = \"{}\")]", m.name);
@@ -298,15 +306,20 @@ impl Kopium {
                         };
                         let spec_trimmed_type = m.type_.as_str().replace(&format!("{}Spec", kind), &kind);
                         if self.builders {
-                            if spec_trimmed_type.starts_with("Option") {
+                            if spec_trimmed_type.starts_with("Option<") {
                                 println!("#[builder(default, setter(strip_option))]");
-                            } else if spec_trimmed_type.starts_with("Vec")
-                                || spec_trimmed_type.starts_with("BTreeMap")
+                            } else if spec_trimmed_type.starts_with("Vec<")
+                                || spec_trimmed_type.starts_with("BTreeMap<")
                             {
                                 println!("#[builder(default)]");
                             }
                         }
-                        println!("    pub {}: {},", safe_name, spec_trimmed_type);
+                        if s.is_enum {
+                            // NB: only supporting plain enumerations atm, not oneOf
+                            println!("    {},", safe_name);
+                        } else {
+                            println!("    pub {}: {},", safe_name, spec_trimmed_type);
+                        }
                     }
                     println!("}}");
                     println!();

--- a/tests/servicemon-crd.yaml
+++ b/tests/servicemon-crd.yaml
@@ -2,9 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -637,9 +634,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
For #39 and #16.

This does not implement sum types properly, it just collects enum members for string constant enums marked as `enum`. The servicemonitor example now generates more accurate structs. Consider the action field as part of `servicemonitor.endpoint.metrics_relabelings`:

```yaml
                          action:
                            default: replace
                            description: Action to perform based on regex matching.
                              Default is 'replace'
                            enum:
                            - replace
                            - keep
                            - drop
                            - hashmod
                            - labelmap
                            - labeldrop
                            - labelkeep
                            type: string
```

produces:

```rust
/// RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
#[derive(Serialize, Deserialize, Clone, Debug)]
pub enum ServiceMonitorEndpointsMetricRelabelingsAction {
    replace,
    keep,
    drop,
    hashmod,
    labelmap,
    labeldrop,
    labelkeep,
}
```

Naming consistency with rust will need to be addressed in a later PR.