### PR TITLE
Update clap to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,17 +79,50 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -137,7 +161,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -346,15 +370,6 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -538,8 +553,9 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "env_logger",
- "heck 0.4.0",
+ "heck",
  "k8s-openapi",
  "kube",
  "log",
@@ -548,7 +564,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "structopt",
  "tokio",
  "typed-builder",
 ]
@@ -804,6 +819,12 @@ checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "parking_lot"
@@ -1147,39 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -1217,12 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1438,18 +1426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,12 +1448,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ anyhow = "1.0.48"
 log = "0.4.14"
 env_logger = "0.9.0"
 serde_json = "1.0.72"
-clap = "2.33"
+clap = { version = "3.1", features = ["cargo", "derive"] }
+clap_complete = "3.1"
 quote = "1.0.10"
 serde = { version = "1.0.130", features = ["derive"] }
-structopt = "0.3"
 serde_yaml = "0.8.23"
 heck = "0.4.0"
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -46,7 +46,7 @@ fn analyze_(
                 // map values is an object with properties
                 debug!("Generating map struct for {} (under {})", current, stack);
                 let new_result =
-                    analyze_object_properties(&extra_props, stack, &mut array_recurse_level, level, &schema)?;
+                    analyze_object_properties(extra_props, stack, &mut array_recurse_level, level, &schema)?;
                 results.extend(new_result);
             } else if !dict_type.is_empty() {
                 warn!("not generating type {} - using {} map", current, dict_type);

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ impl Kopium {
 
         if let Some(schema) = data {
             log::debug!("schema: {}", serde_json::to_string_pretty(&schema)?);
-            let structs = analyze(schema, &kind)?
+            let structs = analyze(schema, kind)?
                 .rename(self.rust_case)
                 .builder_fields(self.builders)
                 .0;
@@ -225,7 +225,7 @@ impl Kopium {
                         }
                     } else {
                         self.print_derives(false);
-                        let spec_trimmed_name = s.name.as_str().replace(&format!("{}Spec", kind), &kind);
+                        let spec_trimmed_name = s.name.as_str().replace(&format!("{}Spec", kind), kind);
                         if s.is_enum {
                             println!("pub enum {} {{", spec_trimmed_name);
                         } else {
@@ -245,7 +245,7 @@ impl Kopium {
                         for annot in m.extra_annot {
                             println!("    {}", annot);
                         }
-                        let spec_trimmed_type = m.type_.as_str().replace(&format!("{}Spec", kind), &kind);
+                        let spec_trimmed_type = m.type_.as_str().replace(&format!("{}Spec", kind), kind);
                         if s.is_enum {
                             // NB: only supporting plain enumerations atm, not oneOf
                             println!("    {},", safe_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,55 +1,56 @@
+use std::path::PathBuf;
+
 use anyhow::{anyhow, Context, Result};
+use clap::{CommandFactory, Parser, Subcommand};
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
     CustomResourceDefinition, CustomResourceDefinitionVersion, CustomResourceSubresources,
 };
 use kopium::{analyze, Container, KEYWORDS};
 use kube::{api, core::Version, Api, Client, ResourceExt};
 use quote::format_ident;
-use std::path::PathBuf;
-use structopt::{clap, StructOpt};
 
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Parser)]
+#[clap(
     version = clap::crate_version!(),
     author = "clux <sszynrae@gmail.com>",
     about = "Kubernetes OPenapI UnMangler",
 )]
 struct Kopium {
     /// Give the name of the input CRD to use e.g. prometheusrules.monitoring.coreos.com
-    #[structopt(conflicts_with("file"))]
+    #[clap(conflicts_with("file"))]
     crd: Option<String>,
 
     /// Point to the location of a CRD to use on disk
-    #[structopt(parse(from_os_str), long = "--filename", short = "f", conflicts_with("crsd"))]
+    #[clap(long = "filename", short, conflicts_with("crd"))]
     file: Option<PathBuf>,
 
     /// Use this CRD version if multiple versions are present
-    #[structopt(long)]
+    #[clap(long)]
     api_version: Option<String>,
 
     /// Do not emit prelude
-    #[structopt(long)]
+    #[clap(long)]
     hide_prelude: bool,
 
     /// Do not emit kube derive instructions; structs only
     ///
     /// If this is set, it makes any kube-derive specific options such as `--schema` unnecessary.
-    #[structopt(long)]
+    #[clap(long)]
     hide_kube: bool,
 
     /// Do not emit inner attributes such as #![allow(non_snake_case)]
     ///
     /// This is useful if you need to consume the code within an include! macro
     /// which does not support inner attributes: https://github.com/rust-lang/rust/issues/47995
-    #[structopt(long, short = "i")]
+    #[clap(long, short = 'i')]
     hide_inner_attr: bool,
 
     /// Emit doc comments from descriptions
-    #[structopt(long, short = "d")]
+    #[clap(long, short)]
     docs: bool,
 
     /// Emit builder derives via the typed_builder crate
-    #[structopt(long, short = "b")]
+    #[clap(long, short)]
     builders: bool,
 
     /// Schema mode to use for kube-derive
@@ -62,7 +63,7 @@ struct Kopium {
     ///
     /// --schema=derived implies `--derive JsonSchema`. The resulting schema will compile without external user action.
     /// The crd via `CustomResourceExt::crd()` can be applied into Kubernetes directly.
-    #[structopt(
+    #[clap(
         long,
         default_value = "disabled",
         possible_values = &["disabled", "manual", "derived"],
@@ -70,13 +71,13 @@ struct Kopium {
     schema: String,
 
     /// Derive these extra traits on generated structs
-    #[structopt(long,
-        short = "D",
+    #[clap(long,
+        short = 'D',
         possible_values = &["Copy", "Default", "PartialEq", "Eq", "PartialOrd", "Ord", "Hash", "JsonSchema"],
     )]
     derive: Vec<String>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Option<Command>,
 
     /// Convert container members to rust casing conventions
@@ -88,7 +89,7 @@ struct Kopium {
     ///
     /// This operation is safe because names are preserved through attributes.
     /// However, while not needing the #![allow(non_snake_case)] inner attribute; your code will be longer.
-    #[structopt(long, short = "z")]
+    #[clap(long, short = 'z')]
     rust_case: bool,
 
     /// Enable all automatation features
@@ -98,25 +99,26 @@ struct Kopium {
     /// It contains an unstable set of of features and may get expanded in the future.
     ///
     /// Setting --auto enables: --schema=derived --derive=JsonSchema --rust-case --docs
-    #[structopt(long, short = "A")]
+    #[clap(long, short = 'A')]
     auto: bool,
 }
 
-#[derive(StructOpt, Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Subcommand)]
+#[clap(args_conflicts_with_subcommands = true)]
 enum Command {
-    #[structopt(about = "List available CRDs", setting(clap::AppSettings::Hidden))]
+    #[clap(about = "List available CRDs", hide = true)]
     ListCrds,
-    #[structopt(about = "Generate completions", setting(clap::AppSettings::Hidden))]
+    #[clap(about = "Generate completions", hide = true)]
     Completions {
-        #[structopt(about = "The shell to generate completions for", possible_values = &clap::Shell::variants())]
-        shell: clap::Shell,
+        #[clap(help = "The shell to generate completions for", possible_values = supported_shells())]
+        shell: clap_complete::Shell,
     },
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
-    let mut args = Kopium::from_args();
+    let mut args = Kopium::parse();
     if args.auto {
         args.docs = true;
         args.rust_case = true;
@@ -154,17 +156,18 @@ impl Kopium {
 
             let crd: CustomResourceDefinition = serde_yaml::from_str(&data)?;
             self.generate(crd).await
-        } else {
-            match self.command {
-                Some(Command::ListCrds) => {
+        } else if let Some(command) = self.command {
+            match command {
+                Command::ListCrds => {
                     let api = Client::try_default()
                         .await
                         .map(Api::<CustomResourceDefinition>::all)?;
                     self.list_crds(api).await
                 }
-                Some(Command::Completions { shell }) => self.completions(shell),
-                None => self.help(),
+                Command::Completions { shell } => self.completions(shell),
             }
+        } else {
+            self.help()
         }
     }
 
@@ -272,16 +275,14 @@ impl Kopium {
         Ok(())
     }
 
-    fn completions(&self, shell: clap::Shell) -> Result<()> {
-        let mut completions = Vec::new();
-        Self::clap().gen_completions_to("kopium", shell, &mut completions);
-        let completions = String::from_utf8(completions)?;
-        println!("{}", completions);
+    fn completions(&self, shell: clap_complete::Shell) -> Result<()> {
+        let mut command = Self::command();
+        clap_complete::generate(shell, &mut command, "kopium", &mut std::io::stdout());
         Ok(())
     }
 
     fn help(&self) -> Result<()> {
-        Self::clap().print_help().map(|_| println!())?;
+        Self::command().print_help()?;
         Ok(())
     }
 
@@ -380,4 +381,8 @@ fn all_versions(crd: &CustomResourceDefinition) -> String {
         .collect::<Vec<_>>();
     vers.sort_by_cached_key(|v| std::cmp::Reverse(Version::parse(v).priority()));
     vers.join(", ")
+}
+
+fn supported_shells() -> Vec<clap::PossibleValue<'static>> {
+    clap_complete::Shell::possible_values().collect()
 }


### PR DESCRIPTION
Now that clapv3 is stable it makes sense to update.

Also as a separate commit small clippy cleanup