### PR TITLE
Nest serde_json::Value under HashMap for preserve-unknown-fields

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -920,7 +920,9 @@ type: object
         assert_eq!(root.level, 0);
         assert_eq!(root.is_enum, false);
         assert_eq!(&root.members[0].name, "patchesStrategicMerge");
-        assert_eq!(&root.members[0].type_, "Option<Vec<HashMap<String, serde_json::Value>>>");
+        assert_eq!(
+            &root.members[0].type_,
+            "Option<Vec<HashMap<String, serde_json::Value>>>"
+        );
     }
-
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -261,7 +261,7 @@ fn analyze_object_properties(
                 } else if value.properties.is_none()
                     && value.x_kubernetes_preserve_unknown_fields.unwrap_or(false)
                 {
-                    dict_key = Some("serde_json::Value".into());
+                    dict_key = Some("HashMap<String, serde_json::Value>".into());
                 }
                 if let Some(dict) = dict_key {
                     format!("BTreeMap<String, {}>", dict)
@@ -295,7 +295,7 @@ fn analyze_object_properties(
                 if value.x_kubernetes_int_or_string.is_some() {
                     "IntOrString".into()
                 } else if value.x_kubernetes_preserve_unknown_fields == Some(true) {
-                    "serde_json::Value".into()
+                    "HashMap<String, serde_json::Value>".into()
                 } else {
                     bail!("unknown empty dict type for {}", key)
                 }
@@ -355,7 +355,7 @@ fn array_recurse_for_type(
         match items {
             JSONSchemaPropsOrArray::Schema(s) => {
                 if s.type_.is_none() && s.x_kubernetes_preserve_unknown_fields == Some(true) {
-                    return Ok(("Vec<serde_json::Value>".into(), level));
+                    return Ok(("Vec<HashMap<String, serde_json::Value>>".into(), level));
                 }
                 let inner_array_type = s.type_.clone().unwrap_or_default();
                 return match inner_array_type.as_ref() {
@@ -556,7 +556,7 @@ type: object
         assert_eq!(server_selector.level, 1);
         let match_labels = &server_selector.members[0];
         assert_eq!(match_labels.name, "matchLabels");
-        assert_eq!(match_labels.type_, "BTreeMap<String, serde_json::Value>");
+        assert_eq!(match_labels.type_, "HashMap<String, serde_json::Value>");
     }
 
     #[test]
@@ -896,4 +896,31 @@ type: object
         assert_eq!(from.type_, "Option<String>");
         assert_eq!(to.type_, "Option<BTreeMap<String, i32>>");
     }
+
+
+    #[test]
+    fn array_of_preserve_unknown_objects() {
+        init();
+        // example from flux kustomization crd
+        let schema_str = r#"
+        properties:
+          patchesStrategicMerge:
+            description: Strategic merge patches, defined as inline YAML objects.
+            items:
+              x-kubernetes-preserve-unknown-fields: true
+            type: array
+        type: object
+        "#;
+
+        let schema: JSONSchemaProps = serde_yaml::from_str(schema_str).unwrap();
+        let structs = analyze(schema, "KustomizationSpec").unwrap().0;
+        println!("got {:?}", structs);
+        let root = &structs[0];
+        assert_eq!(root.name, "KustomizationSpec");
+        assert_eq!(root.level, 0);
+        assert_eq!(root.is_enum, false);
+        assert_eq!(&root.members[0].name, "patchesStrategicMerge");
+        assert_eq!(&root.members[0].type_, "Option<Vec<HashMap<String, serde_json::Value>>>");
+    }
+
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -261,7 +261,7 @@ fn analyze_object_properties(
                 } else if value.properties.is_none()
                     && value.x_kubernetes_preserve_unknown_fields.unwrap_or(false)
                 {
-                    dict_key = Some("HashMap<String, serde_json::Value>".into());
+                    dict_key = Some("serde_json::Value".into());
                 }
                 if let Some(dict) = dict_key {
                     format!("BTreeMap<String, {}>", dict)
@@ -556,7 +556,7 @@ type: object
         assert_eq!(server_selector.level, 1);
         let match_labels = &server_selector.members[0];
         assert_eq!(match_labels.name, "matchLabels");
-        assert_eq!(match_labels.type_, "HashMap<String, serde_json::Value>");
+        assert_eq!(match_labels.type_, "BTreeMap<String, serde_json::Value>");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,6 +331,9 @@ impl Kopium {
         if results.iter().any(|o| o.uses_btreemaps()) {
             println!("use std::collections::BTreeMap;");
         }
+        if results.iter().any(|o| o.uses_hashmaps()) {
+            println!("use std::collections::HashMap;");
+        }
         if results.iter().any(|o| o.uses_datetime()) {
             println!("use chrono::{{DateTime, Utc}};");
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -49,6 +49,10 @@ impl Container {
         self.members.iter().any(|m| m.type_.contains("BTreeMap"))
     }
 
+    pub fn uses_hashmaps(&self) -> bool {
+        self.members.iter().any(|m| m.type_.contains("HashMap"))
+    }
+
     pub fn uses_datetime(&self) -> bool {
         self.members.iter().any(|m| m.type_.contains("DateTime"))
     }


### PR DESCRIPTION
Follow-up to #76.

Adds a unit test case for a part inside flux's kustomization crd that failed before #76.