### PR TITLE
Always rustify member names

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,70 +13,70 @@ test: test-pr test-sm test-mv test-argo test-agent test-certmanager test-cluster
 
 test-pr:
   kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-  cargo run --bin kopium -- prometheusrules.monitoring.coreos.com -iz > tests/gen.rs
+  cargo run --bin kopium -- prometheusrules.monitoring.coreos.com > tests/gen.rs
   echo "pub type CR = PrometheusRule;" >> tests/gen.rs
   kubectl apply -f tests/pr.yaml
   cargo test --test runner -- --nocapture
 
 test-sm:
   kubectl apply --force-conflicts --server-side -f tests/servicemon-crd.yaml
-  cargo run --bin kopium -- -izdf tests/servicemon-crd.yaml > tests/gen.rs
+  cargo run --bin kopium -- -df tests/servicemon-crd.yaml > tests/gen.rs
   echo "pub type CR = ServiceMonitor;" >> tests/gen.rs
   kubectl apply -f tests/servicemon.yaml
   cargo test --test runner -- --nocapture
 
 test-mv:
   kubectl apply -f tests/mv-crd.yaml
-  cargo run --bin kopium -- multiversions.clux.dev -iA > tests/gen.rs
+  cargo run --bin kopium -- multiversions.clux.dev -A > tests/gen.rs
   echo "pub type CR = MultiVersion;" >> tests/gen.rs
   kubectl apply -f tests/mv.yaml
   cargo test --test runner -- --nocapture
 
 test-agent:
   kubectl apply -f tests/agent-crd.yaml
-  cargo run --bin kopium -- -ibAf tests/agent-crd.yaml > tests/gen.rs
+  cargo run --bin kopium -- -bAf tests/agent-crd.yaml > tests/gen.rs
   echo "pub type CR = Agent;" >> tests/gen.rs
   kubectl apply -f tests/agent.yaml
   cargo test --test runner -- --nocapture
 
 test-argo:
   kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/crds/application-crd.yaml
-  cargo run --bin kopium -- -i applications.argoproj.io > tests/gen.rs
+  cargo run --bin kopium -- applications.argoproj.io > tests/gen.rs
   echo "pub type CR = Application;" >> tests/gen.rs
   kubectl apply -f tests/app.yaml
   cargo test --test runner -- --nocapture
 
 test-certmanager:
   kubectl apply --force-conflicts --server-side -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
-  cargo run --bin kopium -- -di certificates.cert-manager.io > tests/gen.rs
+  cargo run --bin kopium -- -d certificates.cert-manager.io > tests/gen.rs
   echo "pub type CR = Certificate;" >> tests/gen.rs
   kubectl apply -f tests/cert.yaml
   cargo test --test runner -- --nocapture
 
 test-cluster:
   kubectl apply -f tests/cluster-crd.yaml
-  cargo run --bin kopium -- -f tests/cluster-crd.yaml -di > tests/gen.rs
+  cargo run --bin kopium -- -f tests/cluster-crd.yaml -d > tests/gen.rs
   echo "pub type CR = Cluster;" >> tests/gen.rs
   # No test instance for this crd
   cargo build --test runner
 
 test-linkerd-serverauth:
   kubectl apply --server-side -f tests/serverauth-crd.yaml
-  cargo run --bin kopium -- -di serverauthorizations.policy.linkerd.io > tests/gen.rs
+  cargo run --bin kopium -- -d serverauthorizations.policy.linkerd.io > tests/gen.rs
   echo "pub type CR = ServerAuthorization;" >> tests/gen.rs
   kubectl apply -f tests/serverauth.yaml
   cargo test --test runner -- --nocapture
 
 test-linkerd-server:
   #kubectl apply --server-side -f tests/server-crd.yaml
-  #cargo run --bin kopium -- -ibz servers.policy.linkerd.io > tests/gen.rs
+  #cargo run --bin kopium -- -b servers.policy.linkerd.io > tests/gen.rs
   #echo "pub type CR = Server;" >> tests/gen.rs
   #kubectl apply -f tests/server.yaml
   #cargo test --test runner -- --nocapture
 
 test-istio-destrule:
   kubectl apply --server-side -f tests/destinationrule-crd.yaml
-  cargo run --bin kopium -- destinationrules.networking.istio.io -i > tests/gen.rs
+  cargo run --bin kopium -- destinationrules.networking.istio.io > tests/gen.rs
   echo "pub type CR = DestinationRule;" >> tests/gen.rs
   kubectl apply -f tests/destinationrule.yaml
   # NB: this currently fails because of an empty status object with preserve-unknown-fields

--- a/src/output.rs
+++ b/src/output.rs
@@ -105,11 +105,11 @@ impl Output {
     ///
     /// Converts [*].members[*].name to snake_case for structs, PascalCase for enums,
     /// and adds a serde(rename = "orig_name") annotation to `serde_annot`.
-    pub fn rename(mut self, rust_case: bool) -> Self {
-        if rust_case {
-            for c in &mut self.0 {
-                c.rename()
-            }
+    ///
+    /// It is unsound to skip this step. Some CRDs use kebab-cased members is invalid in Rust.
+    pub fn rename(mut self) -> Self {
+        for c in &mut self.0 {
+            c.rename()
         }
         self
     }


### PR DESCRIPTION
Breaking change to make variables always follow rust conventions.

This avoids a number of problems:

- the need to omit an inner attribute in a generated file to allow
  non_snake_cased vars (see #69)
- unhelpful crashes because of non-rust conventioned keys (see #81)

And as a result we get to remove two options that generally had a
"correct choice"

- `--rust-case` or `-z` (now implied default) so option removed
- `--hide-inner-attr` or `-i` only mattered if you didn't use `-z` so removed

Thus the generated case for crds now always follow the standard rust convention:
- `struct` members use `snake_case`
- `enum` members use `PascalCase`

(and this is a safe rename because we knew the original name so we just emit a serde(rename) attr to ensure serialization uses the correct keys)