### PR TITLE
Stop auto-deriving default for enum

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -64,6 +64,14 @@ impl Container {
     pub fn uses_int_or_string(&self) -> bool {
         self.members.iter().any(|m| m.type_.contains("IntOrString"))
     }
+
+    pub fn is_root(&self) -> bool {
+        self.level == 0
+    }
+
+    pub fn is_main_container(&self) -> bool {
+        self.level == 1 && self.name.ends_with("Spec")
+    }
 }
 
 impl Container {


### PR DESCRIPTION
Closes #87 

Still remains to actually handle the default attribute (when it exists), but at least this will unblock users.