### PR TITLE
Fix `Container` recursion into `additionalProperties`

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -73,9 +73,8 @@ fn analyze_(
     //
     // again; additionalProperties XOR properties
     let extras = if let Some(JSONSchemaPropsOrBool::Schema(s)) = schema.additional_properties.as_ref() {
-        let props2 = s.properties.clone().unwrap_or_default();
-        // NB: bumping level here as a precaution to disambiguate
-        find_containers(&props2, stack, &mut array_recurse_level, level + 1, &schema)?
+        let extra_props = s.properties.clone().unwrap_or_default();
+        find_containers(&extra_props, stack, &mut array_recurse_level, level, &schema)?
     } else {
         // regular properties only
         find_containers(&props, stack, &mut array_recurse_level, level, &schema)?

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -36,7 +36,7 @@ fn analyze_(
     let mut array_recurse_level: HashMap<String, u8> = Default::default();
 
     // create a Container if we have a container type:
-    debug!("in main analyze with {} + {}", current, stack);
+    //trace!("analyze_ with {} + {}", current, stack);
     if schema.type_.clone().unwrap_or_default() == "object" {
         // we can have additionalProperties XOR properties
         // https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
@@ -115,9 +115,7 @@ fn find_containers(
                 // objects, maps
                 let mut handled_inner = false;
                 if let Some(JSONSchemaPropsOrBool::Schema(s)) = &value.additional_properties {
-                    debug!("got props {}", serde_yaml::to_string(s).unwrap());
                     let dict_type = s.type_.clone().unwrap_or_default();
-                    debug!("dict type is {}", dict_type);
                     if dict_type == "array" {
                         // unpack the inner object from the array wrap
                         if let Some(JSONSchemaPropsOrArray::Schema(items)) = &s.as_ref().items {
@@ -135,7 +133,6 @@ fn find_containers(
                 }
                 if !handled_inner {
                     // normal object recurse
-                    debug!("regular recurse for {}", next_key);
                     analyze_(value, &next_key, &next_stack, level + 1, &mut results)?;
                 }
             }
@@ -281,7 +278,6 @@ fn extract_container(
                                 }
                             }
                             "object" => {
-                                // look for nested items first
                                 // cluster test with `failureDomains` uses this spec format
                                 Some(format!("{}{}", stack, uppercase_first_letter(key)))
                             }
@@ -328,7 +324,6 @@ fn extract_container(
                     array_type, key, recurse_level
                 );
                 array_recurse_level.insert(key.clone(), recurse_level);
-                // TODO: where is the struct for the inline array generated?
                 array_type
             }
             "" => {
@@ -342,7 +337,6 @@ fn extract_container(
             }
             x => bail!("unknown type {}", x),
         };
-        debug!("analyze end type: {}", rust_type);
 
         // Create member and wrap types correctly
         let member_doc = value.description.clone();

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -13,7 +13,7 @@ const IGNORED_KEYS: [&str; 3] = ["metadata", "apiVersion", "kind"];
 /// All found output structs will have its names prefixed by the kind it is for
 pub fn analyze(schema: JSONSchemaProps, kind: &str) -> Result<Output> {
     let mut res = vec![];
-    analyze_(schema, "", kind, 0, &mut res)?;
+    analyze_(&schema, "", kind, 0, &mut res)?;
     Ok(Output(res))
 }
 
@@ -26,7 +26,7 @@ pub fn analyze(schema: JSONSchemaProps, kind: &str) -> Result<Output> {
 /// level: recursion level (start at 0)
 /// results: multable list of generated structs (not deduplicated)
 fn analyze_(
-    schema: JSONSchemaProps,
+    schema: &JSONSchemaProps,
     current: &str,
     stack: &str,
     level: u8,
@@ -34,10 +34,10 @@ fn analyze_(
 ) -> Result<()> {
     let props = schema.properties.clone().unwrap_or_default();
     let mut array_recurse_level: HashMap<String, u8> = Default::default();
-    // first generate the object if it is one
-    let current_type = schema.type_.clone().unwrap_or_default();
+
+    // create a Container if we have a container type:
     debug!("in main analyze with {} + {}", current, stack);
-    if current_type == "object" {
+    if schema.type_.clone().unwrap_or_default() == "object" {
         // we can have additionalProperties XOR properties
         // https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
         if let Some(JSONSchemaPropsOrBool::Schema(s)) = schema.additional_properties.as_ref() {
@@ -46,9 +46,8 @@ fn analyze_(
             if let Some(extra_props) = &s.properties {
                 // map values is an object with properties
                 debug!("Generating map struct for {} (under {})", current, stack);
-                let new_result =
-                    analyze_object_properties(extra_props, stack, &mut array_recurse_level, level, &schema)?;
-                results.extend(new_result);
+                let c = extract_container(extra_props, stack, &mut array_recurse_level, level, &schema)?;
+                results.push(c);
             } else if !dict_type.is_empty() {
                 warn!("not generating type {} - using {} map", current, dict_type);
                 return Ok(()); // no members here - it'll be inlined
@@ -61,20 +60,52 @@ fn analyze_(
                 warn!("not generating type {} - using BTreeMap", current);
                 return Ok(());
             }
-            let new_result =
-                analyze_object_properties(&props, stack, &mut array_recurse_level, level, &schema)?;
-            results.extend(new_result);
+            let c = extract_container(&props, stack, &mut array_recurse_level, level, &schema)?;
+            results.push(c);
         }
     }
-    debug!("done analyzing, now for recursing for structs: {}", serde_yaml::to_string(&props).unwrap());
     debug!("full schema here: {}", serde_yaml::to_string(&schema).unwrap());
 
-    // Start recursion for properties
-    for (key, value) in props.clone() {
+    // If the container has members, we recurse through these members to find more containers.
+    // NB: find_containers initiates recursion **for this container** and will end up invoking this fn,
+    // so that we can create the Container with its members (same fn, above) in one step.
+    // Once the Container has been made, we drop down here and restarting the process for its members.
+    //
+    // again; additionalProperties XOR properties
+    let extras = if let Some(JSONSchemaPropsOrBool::Schema(s)) = schema.additional_properties.as_ref() {
+        let props2 = s.properties.clone().unwrap_or_default();
+        // NB: bumping level here as a precaution to disambiguate
+        find_containers(&props2, stack, &mut array_recurse_level, level + 1, &schema)?
+    } else {
+        // regular properties only
+        find_containers(&props, stack, &mut array_recurse_level, level, &schema)?
+    };
+    results.extend(extras);
+
+    Ok(())
+}
+
+
+/// Dive into passed properties
+///
+/// This will recursively invoke the analyzer from any new type that needs investigation.
+/// Upon recursion, we concatenate container names (so they are always unique across the tree)
+/// and bump the level to have a way to sort the containers by depth.
+fn find_containers(
+    props: &BTreeMap<String, JSONSchemaProps>,
+    stack: &str,
+    array_recurse_level: &mut HashMap<String, u8>,
+    level: u8,
+    schema: &JSONSchemaProps,
+) -> Result<Vec<Container>> {
+    //trace!("finding containers in: {}", serde_yaml::to_string(&props)?);
+    let mut results = vec![];
+    for (key, value) in props {
         if level == 0 && IGNORED_KEYS.contains(&(key.as_ref())) {
             debug!("not recursing into ignored {}", key); // handled elsewhere
             continue;
         }
+        debug!("found additional key {}", key);
         let next_key = uppercase_first_letter(&key);
         let next_stack = format!("{}{}", stack, next_key);
         let value_type = value.type_.clone().unwrap_or_default();
@@ -90,7 +121,7 @@ fn analyze_(
                     if dict_type == "array" {
                         // unpack the inner object from the array wrap
                         if let Some(JSONSchemaPropsOrArray::Schema(items)) = &s.as_ref().items {
-                            analyze_(*items.clone(), &next_key, &next_stack, level + 1, results)?;
+                            analyze_(items, &next_key, &next_stack, level + 1, &mut results)?;
                             handled_inner = true;
                         }
                     }
@@ -105,11 +136,11 @@ fn analyze_(
                 if !handled_inner {
                     // normal object recurse
                     debug!("regular recurse for {}", next_key);
-                    analyze_(value, &next_key, &next_stack, level + 1, results)?;
+                    analyze_(value, &next_key, &next_stack, level + 1, &mut results)?;
                 }
             }
             "array" => {
-                if let Some(recurse) = array_recurse_level.get(&key).cloned() {
+                if let Some(recurse) = array_recurse_level.get(key).cloned() {
                     let mut inner = value.clone();
                     for _i in 0..recurse {
                         debug!("recursing into props for {}", key);
@@ -125,7 +156,7 @@ fn analyze_(
                             bail!("could not recurse into vec");
                         }
                     }
-                    analyze_(inner, &next_key, &next_stack, level + 1, results)?;
+                    analyze_(&inner, &next_key, &next_stack, level + 1, &mut results)?;
                 }
             }
             "" => {
@@ -136,7 +167,7 @@ fn analyze_(
                 }
             }
             x => {
-                if let Some(en) = value.enum_ {
+                if let Some(en) = &value.enum_ {
                     // plain enums do not need to recurse, can collect it here
                     let new_result = analyze_enum_properties(&en, &next_stack, level, &schema)?;
                     results.push(new_result);
@@ -146,94 +177,9 @@ fn analyze_(
             }
         }
     }
-    // also recurse into additionalProperties
-    if let Some(JSONSchemaPropsOrBool::Schema(s)) = schema.additional_properties.as_ref() {
-        let props = s.properties.clone().unwrap_or_default();
-        // TODO: body here the same as above. fn wrap this.
-
-        for (key, value) in props {
-            if level == 0 && IGNORED_KEYS.contains(&(key.as_ref())) {
-                debug!("not recursing into ignored {}", key); // handled elsewhere
-                continue;
-            }
-            debug!("found additional key {}", key);
-            let next_key = uppercase_first_letter(&key);
-            let next_stack = format!("{}{}", stack, next_key);
-            let value_type = value.type_.clone().unwrap_or_default();
-            match value_type.as_ref() {
-                "object" => {
-                    debug!("obj recurse for {}", key);
-                    // objects, maps
-                    let mut handled_inner = false;
-                    if let Some(JSONSchemaPropsOrBool::Schema(s)) = &value.additional_properties {
-                        debug!("got props {}", serde_yaml::to_string(s).unwrap());
-                        let dict_type = s.type_.clone().unwrap_or_default();
-                        debug!("dict type is {}", dict_type);
-                        if dict_type == "array" {
-                            // unpack the inner object from the array wrap
-                            if let Some(JSONSchemaPropsOrArray::Schema(items)) = &s.as_ref().items {
-                                analyze_(*items.clone(), &next_key, &next_stack, level + 1, results)?;
-                                handled_inner = true;
-                            }
-                        }
-                        // TODO: not sure if these nested recurses are necessary - cluster test case does not have enough data
-                        //if let Some(extra_props) = &s.properties {
-                        //    for (_key, value) in extra_props {
-                        //        debug!("nested recurse into {} {} - key: {}", next_key, next_stack, _key);
-                        //        analyze_(value.clone(), &next_key, &next_stack, level +1, results)?;
-                        //    }
-                        //}
-                    }
-                    if !handled_inner {
-                        // normal object recurse
-                        debug!("regular recurse for {}", next_key);
-                        analyze_(value, &next_key, &next_stack, level + 1, results)?;
-                    }
-                }
-                "array" => {
-                    if let Some(recurse) = array_recurse_level.get(&key).cloned() {
-                        let mut inner = value.clone();
-                        for _i in 0..recurse {
-                            debug!("recursing into props for {}", key);
-                            if let Some(sub) = inner.items {
-                                match sub {
-                                    JSONSchemaPropsOrArray::Schema(s) => {
-                                        //info!("got inner: {}", serde_json::to_string_pretty(&s)?);
-                                        inner = *s.clone();
-                                    }
-                                    _ => bail!("only handling single type in arrays"),
-                                }
-                            } else {
-                                bail!("could not recurse into vec");
-                            }
-                        }
-                        analyze_(inner, &next_key, &next_stack, level + 1, results)?;
-                    }
-                }
-                "" => {
-                    if value.x_kubernetes_int_or_string.is_some() {
-                        debug!("not recursing into IntOrString {}", key)
-                    } else {
-                        debug!("not recursing into unknown empty type {}", key)
-                    }
-                }
-                x => {
-                    if let Some(en) = value.enum_ {
-                        // plain enums do not need to recurse, can collect it here
-                        let new_result = analyze_enum_properties(&en, &next_stack, level, &schema)?;
-                        results.push(new_result);
-                    } else {
-                        debug!("not recursing into {} ('{}' is not a container)", key, x)
-                    }
-                }
-            }
-        }
-
-
-    }
-
-    Ok(())
+    Ok(results)
 }
+
 
 // helper to figure out what output enums and embedded members are contained in the current object schema
 fn analyze_enum_properties(
@@ -272,15 +218,14 @@ fn analyze_enum_properties(
 }
 
 
-// helper to figure out what output structs (returned) and embedded members are contained in the current object schema
-fn analyze_object_properties(
+// fully populate a Container with all its members given the current stack and schema position
+fn extract_container(
     props: &BTreeMap<String, JSONSchemaProps>,
     stack: &str,
     array_recurse_level: &mut HashMap<String, u8>,
     level: u8,
     schema: &JSONSchemaProps,
-) -> Result<Vec<Container>, anyhow::Error> {
-    let mut results = vec![];
+) -> Result<Container, anyhow::Error> {
     let mut members = vec![];
     //debug!("analyzing object {}", serde_json::to_string(&schema).unwrap());
     debug!("analyze object props in {}", stack);
@@ -429,14 +374,13 @@ fn analyze_object_properties(
             // probably better to do impl Default to avoid having to make custom fns
         }
     }
-    results.push(Container {
+    Ok(Container {
         name: stack.to_string(),
         members,
         level,
         docs: schema.description.clone(),
         is_enum: false,
-    });
-    Ok(results)
+    })
 }
 
 // recurse into an array type to find its nested type


### PR DESCRIPTION
Fixes #84.

This factors out the part of the recursion that identifies members and starts the recursion again with those members.
This is needed because there are really two ways we can dig into properties:
- through properties
- through additionalProperties

We already have known its `properties XOR additionalProperties`, but we only correctly did the recursion of that for the members, not for further structs. This meant that complicated schemas with structs nested within additionalProperties were never fully populated (although their members might have been referenced correctly).