### PR TITLE
Do not try to derive `CustomResource` when using `--hide-kube`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -280,7 +280,7 @@ impl Kopium {
             .into_iter()
             .map(String::from)
             .collect();
-        if s.is_main_container() {
+        if s.is_main_container() && !self.hide_kube {
             // CustomResource first for root struct
             derives.insert(0, "CustomResource".to_string());
         }


### PR DESCRIPTION
Fixes #96