### PR TITLE
Allow integer enums to have correct integer serialization

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -36,7 +36,7 @@ fn analyze_(
     let mut array_recurse_level: HashMap<String, u8> = Default::default();
 
     // create a Container if we have a container type:
-    //trace!("analyze_ with {} + {}", current, stack);
+    trace!("analyze_ with {} + {}", current, stack);
     if schema.type_.clone().unwrap_or_default() == "object" {
         // we can have additionalProperties XOR properties
         // https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
@@ -190,13 +190,13 @@ fn analyze_enum_properties(
     for en in items {
         debug!("got enum {:?}", en);
         // TODO: do we need to verify enum elements? only in oneOf only right?
-        let name = match &en.0 {
-            serde_json::Value::String(name) => name.to_string(),
+        let (name, disc) = match &en.0 {
+            serde_json::Value::String(name) => (name.to_string(), None),
             serde_json::Value::Number(val) => {
                 if !val.is_u64() {
                     bail!("enum member cannot have signed/floating discriminants");
                 }
-                val.to_string()
+                (val.to_string(), Some(val.as_u64().unwrap()))
             }
             _ => bail!("not handling non-string/int enum outside oneOf block"),
         };
@@ -210,6 +210,7 @@ fn analyze_enum_properties(
             serde_annot: vec![],
             extra_annot: vec![],
             docs: member_doc,
+            discriminant: disc,
         })
     }
     Ok(Container {
@@ -350,6 +351,7 @@ fn extract_container(
                 serde_annot: vec![],
                 extra_annot: vec![],
                 docs: member_doc,
+                discriminant: None,
             })
         } else {
             // option wrapping needed if not required
@@ -363,6 +365,7 @@ fn extract_container(
                 ],
                 extra_annot: vec![],
                 docs: member_doc,
+                discriminant: None,
             })
             // TODO: must capture `default` key here instead of blindly using serde default
             // this will require us storing default properties for the member in above loop

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,11 @@ impl Kopium {
                         let spec_trimmed_type = m.type_.as_str().replace(&format!("{}Spec", kind), kind);
                         if s.is_enum {
                             // NB: only supporting plain enumerations atm, not oneOf
-                            println!("    {},", name);
+                            if let Some(d) = m.discriminant {
+                                println!("    {} = {},", name, d);
+                            } else {
+                                println!("    {},", name);
+                            }
                         } else {
                             println!("    pub {}: {},", name, spec_trimmed_type);
                         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -42,6 +42,8 @@ pub struct Member {
     pub extra_annot: Vec<String>,
     /// Documentation properties extracted from the property
     pub docs: Option<String>,
+    /// Discriminant of an integer enum
+    pub discriminant: Option<u64>,
 }
 
 impl Container {


### PR DESCRIPTION
- [x] Add discriminant to integer enums
- [ ] Add [`serde_repr`](https://serde.rs/enum-number.html)
- [ ] Drop `#[serde(rename)]` attrs on `serde_repr` enums

Last thing I want to fix before next release.