### PR TITLE
Allow piping into everything by ignoring SIGPIPE errors from `println`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,7 @@ dependencies = [
  "heck",
  "k8s-openapi",
  "kube",
+ "libc",
  "log",
  "quote",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.186", features = ["derive"] }
 serde_yaml = "0.9.25"
 heck = "0.4.1"
 syn = "2.0.29"
+libc = "0.2.147"
 
 [dependencies.kube]
 version = "0.85.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,12 @@ enum Command {
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
+    // Ignore SIGPIPE errors to avoid having to use let _ = write! everywhere
+    // See https://github.com/rust-lang/rust/issues/46016
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let mut args = Kopium::parse();
     if args.auto {
         args.docs = true;


### PR DESCRIPTION
There is a future nightly feature to avoid the unsafe use, but this is fairly innocuous to me.
Have used it in most of my CLIs before, and would like to do `kopium crd | something -` without kopium crashing if `something` exits early.