### PR TITLE
argo workflow wip

### DIFF
--- a/justfile
+++ b/justfile
@@ -42,6 +42,13 @@ test-argo:
   kubectl apply -f tests/app.yaml
   cargo test --test runner -- --nocapture
 
+test-argowf:
+  kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/argoproj/argo-workflows/master/manifests/base/crds/full/argoproj.io_workflows.yaml
+  cargo run --bin kopium -- workflows.argoproj.io > tests/gen.rs
+  echo "pub type CR = Workflow;" >> tests/gen.rs
+  kubectl apply -f test/wf.yaml
+  cargo test --test runner -- --nocapture
+
 test-certmanager:
   kubectl apply --force-conflicts --server-side -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
   cargo run --bin kopium -- -d certificates.cert-manager.io > tests/gen.rs

--- a/tests/wf.yaml
+++ b/tests/wf.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: gen
+spec:
+  entrypoint: argo-cd-ci
+  arguments:
+    parameters:
+    - name: revision
+      value: master
+    - name: repo
+      value: https://github.com/argoproj/argo-cd.git
+  volumes:
+    - name: tmp
+      emptyDir: {}
+  templates:
+  - name: ci-builder
+    inputs:
+      parameters:
+      - name: cmd
+      artifacts:
+      - name: code
+        path: /go/src/github.com/argoproj/argo-cd
+        git:
+          repo: "{{workflow.parameters.repo}}"
+          revision: "{{workflow.parameters.revision}}"
+    container:
+      image: argoproj/argo-cd-ci-builder:v0.13.1
+      imagePullPolicy: Always
+      command: [bash, -c]
+      args: ["{{inputs.parameters.cmd}}"]
+      workingDir: /go/src/github.com/argoproj/argo-cd
+      resources:
+        requests:
+          memory: 1024Mi
+          cpu: 200m
+    archiveLocation:
+      archiveLogs: true


### PR DESCRIPTION
had a quick go to look at #108 and wrote a quick integration setup for it

ultimately it looks like their schema is not valid?

```
kubectl apply --force-conflicts --server-side -f https://raw.githubusercontent.com/argoproj/argo-workflows/master/manifests/base/crds/full/argoproj.io_workflows.yaml
The CustomResourceDefinition "workflows.argoproj.io" is invalid:
* spec.validation.openAPIV3Schema.properties[spec].properties[templateDefaults].properties[dag].properties[tasks].items.properties[inline].type: Required value: must not be empty for specified object fields
* spec.validation.openAPIV3Schema.properties[spec].properties[templateDefaults].properties[steps].items.items: Required value: must be specified
* spec.validation.openAPIV3Schema.properties[spec].properties[templates].items.properties[dag].properties[tasks].items.properties[inline].type: Required value: must not be empty for specified object fields
* spec.validation.openAPIV3Schema.properties[spec].properties[templates].items.properties[steps].items.items: Required value: must be specified
* spec.validation.openAPIV3Schema.properties[status].properties[storedTemplates].additionalProperties.properties[dag].properties[tasks].items.properties[inline].type: Required value: must not be empty for specified object fields
* spec.validation.openAPIV3Schema.properties[status].properties[storedTemplates].additionalProperties.properties[steps].items.items: Required value: must be specified
* spec.validation.openAPIV3Schema.properties[status].properties[storedWorkflowTemplateSpec].properties[templateDefaults].properties[dag].properties[tasks].items.properties[inline].type: Required value: must not be empty for specified object fields
* spec.validation.openAPIV3Schema.properties[status].properties[storedWorkflowTemplateSpec].properties[templateDefaults].properties[steps].items.items: Required value: must be specified
* spec.validation.openAPIV3Schema.properties[status].properties[storedWorkflowTemplateSpec].properties[templates].items.properties[dag].properties[tasks].items.properties[inline].type: Required value: must not be empty for specified object fields
* spec.validation.openAPIV3Schema.properties[status].properties[storedWorkflowTemplateSpec].properties[templates].items.properties[steps].items.items: Required value: must be specified
error: Recipe `test-argowf` failed on line 46 with exit code 1
```

leaving this here in case someone is interested. this isn't super important to me as i don't use argo.