### PR TITLE
Prevent some more crashes on strange var/enum choices

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -101,7 +101,7 @@ impl Container {
             } else if m.name == "-" {
                 "kopium_dash".to_owned()
             } else if m.name == "_" {
-                "kopium_undescore".to_owned()
+                "kopium_underscore".to_owned()
             } else {
                 Container::try_escape_name(m.name.to_snake_case())
                     .unwrap_or_else(|| panic!("invalid field name '{}' could not be escaped", m.name))

--- a/src/output.rs
+++ b/src/output.rs
@@ -98,15 +98,13 @@ impl Container {
                 };
 
                 Container::try_escape_name(name).unwrap_or_else(|| format!("KopiumVariant{i}"))
+            } else if m.name == "-" {
+                "kopium_dash".to_owned()
+            } else if m.name == "_" {
+                "kopium_undescore".to_owned()
             } else {
-                if m.name == "-" {
-                    "kopium_dash".to_owned()
-                } else if m.name == "_" {
-                    "kopium_undescore".to_owned()
-                } else {
-                    Container::try_escape_name(m.name.to_snake_case())
-                        .unwrap_or_else(|| panic!("invalid field name '{}' could not be escaped", m.name))
-                }
+                Container::try_escape_name(m.name.to_snake_case())
+                    .unwrap_or_else(|| panic!("invalid field name '{}' could not be escaped", m.name))
             };
 
             if new_name != m.name {

--- a/src/output.rs
+++ b/src/output.rs
@@ -89,14 +89,24 @@ impl Container {
                 // `!=` -> `!=` -> `r#!=` -> `r#_!=` -> `KopiumVariant{i}`
                 let name = if m.name.is_empty() {
                     "KopiumEmpty".to_owned()
+                } else if m.name == "-" {
+                    "KopiumDash".to_owned()
+                } else if m.name == "_" {
+                    "KopiumUnderscore".to_owned()
                 } else {
                     m.name.to_pascal_case()
                 };
 
-                Container::try_esacape_name(name).unwrap_or_else(|| format!("KopiumVariant{i}"))
+                Container::try_escape_name(name).unwrap_or_else(|| format!("KopiumVariant{i}"))
             } else {
-                Container::try_esacape_name(m.name.to_snake_case())
-                    .unwrap_or_else(|| panic!("invalid field name '{}' could not be escaped", m.name))
+                if m.name == "-" {
+                    "kopium_dash".to_owned()
+                } else if m.name == "_" {
+                    "kopium_undescore".to_owned()
+                } else {
+                    Container::try_escape_name(m.name.to_snake_case())
+                        .unwrap_or_else(|| panic!("invalid field name '{}' could not be escaped", m.name))
+                }
             };
 
             if new_name != m.name {
@@ -119,7 +129,7 @@ impl Container {
     }
 
     /// Tries to escape a field or variant name into a valid Rust identifier.
-    fn try_esacape_name(name: String) -> Option<String> {
+    fn try_escape_name(name: String) -> Option<String> {
         if syn::parse_str::<syn::Ident>(&name).is_ok() {
             return Some(name);
         }


### PR DESCRIPTION
fixes #166

tested locally with `cargo run -- -f vmop.yaml` on the referenced victoriametrics crd