### PR TITLE
add support for standard Condition APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ checksum = "550f99d93aa4c2b25de527bce492d772caf5e21d7ac9bd4b508ba781c8d91e30"
 dependencies = [
  "base64",
  "chrono",
+ "schemars",
  "serde",
  "serde-value",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ name = "kopium"
 path = "src/lib.rs"
 
 [dependencies]
-k8s-openapi = { version = "0.21.1", features = ["latest"] }
 tokio = { version = "1.26.0", features = ["full"] }
 anyhow = "1.0.80"
 log = "0.4.21"
@@ -41,6 +40,10 @@ heck = "0.4.1"
 syn = "2.0.52"
 libc = "0.2.153"
 
+[dependencies.k8s-openapi]
+version = "0.21.1"
+features = ["latest"]
+
 [dependencies.kube]
 version = "0.88.1"
 features = ["derive"]
@@ -48,3 +51,7 @@ features = ["derive"]
 [dev-dependencies]
 schemars = "0.8.16"
 typed-builder = "0.18.1"
+
+[dev-dependencies.k8s-openapi]
+version = "0.21.1"
+features = ["latest", "schemars"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #[macro_use] extern crate log;
 
 mod analyzer;
-pub use analyzer::analyze;
+pub use analyzer::{analyze, Config};
 mod output;
 pub use output::{Container, Member, Output};

--- a/src/output.rs
+++ b/src/output.rs
@@ -72,6 +72,10 @@ impl Container {
     pub fn is_main_container(&self) -> bool {
         self.level == 1 && self.name.ends_with("Spec")
     }
+
+    pub fn contains_conditions(&self) -> bool {
+        self.members.iter().any(|m| m.type_.contains("Vec<Condition>"))
+    }
 }
 
 impl Container {


### PR DESCRIPTION
Detect the presence of a Conditions object in a schema and use `k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition` if present. Introduce a new flag `--no-condition` which allows revering back to the old behavior of generating a custom Condition API for each instance.

Furthermore, introduce `analyzer::Config` which allows for customizing the behavior of the `analyze` function.

Fixes #199 