### PR TITLE
conditionally render status line

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -73,6 +73,10 @@ impl Container {
         self.level == 1 && self.name.ends_with("Spec")
     }
 
+    pub fn is_status_container(&self) -> bool {
+        self.level == 1 && self.name.ends_with("Status")
+    }
+
     pub fn contains_conditions(&self) -> bool {
         self.members.iter().any(|m| m.type_.contains("Vec<Condition>"))
     }


### PR DESCRIPTION
I was trying to get the Istio resources working which do not specify their `status` fields but rather use `x-kubernetes-preserve-unknown-fields`. Currently kopium does not generate a `XyzStatus` struct for that but still adds a `#[kube(status = "XyzStatus")]` line to the `spec` struct which causes compile errors. This PR changes that so that the status line is only added if we have an actual status container and that container has members. In every other case, kopium does not generate a status struct and uses a BTreeMap instead which cannot be used in the `#[kube(status = ...)]` line.

I'm not entirely sure if this breaks anything else down the line, however I was able to generate & `cargo check` every custom resource in https://github.com/metio/kube-custom-resources-rs/pull/222 with this change. 