### PR TITLE
Make map-type an enum and make map usage consistent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 
 mod analyzer;
 pub use analyzer::{analyze, Config};
 mod output;
-pub use output::{Container, Member, Output};
+pub use output::{Container, MapType, Member, Output};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate log;
+#[macro_use] extern crate log;
 
 mod analyzer;
 pub use analyzer::{analyze, Config};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 use std::path::PathBuf;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 use anyhow::{anyhow, Context, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
     CustomResourceDefinition, CustomResourceDefinitionVersion,
 };
-use kopium::{analyze, Config, Container};
+use kopium::{analyze, Config, Container, MapType};
 use kube::{api, core::Version, Api, Client, ResourceExt};
 use quote::format_ident;
 
@@ -104,11 +105,9 @@ struct Kopium {
     #[arg(long)]
     no_condition: bool,
 
-    /// Use BTreeMap to represent the map (additionalProperties) types.
-    ///
-    /// If false, HashMap is defaulted in representing the map types.
+    /// Type used to represent maps via additionalProperties
     #[arg(long)]
-    btreemap: bool,
+    map_type: Option<MapType>,
 }
 
 #[derive(Clone, Copy, Debug, Subcommand)]
@@ -205,7 +204,7 @@ impl Kopium {
             log::debug!("schema: {}", serde_json::to_string_pretty(&schema)?);
             let cfg = Config {
                 no_condition: self.no_condition,
-                btreemap: self.btreemap,
+                map: self.map_type.unwrap_or_default(),
                 relaxed: self.relaxed,
             };
             let structs = analyze(schema, kind, cfg)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
-#[macro_use]
-extern crate log;
+#[macro_use] extern crate log;
 use anyhow::{anyhow, Context, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,8 +105,8 @@ struct Kopium {
     no_condition: bool,
 
     /// Type used to represent maps via additionalProperties
-    #[arg(long)]
-    map_type: Option<MapType>,
+    #[arg(long, value_enum, default_value_t)]
+    map_type: MapType,
 }
 
 #[derive(Clone, Copy, Debug, Subcommand)]
@@ -203,7 +203,7 @@ impl Kopium {
             log::debug!("schema: {}", serde_json::to_string_pretty(&schema)?);
             let cfg = Config {
                 no_condition: self.no_condition,
-                map: self.map_type.unwrap_or_default(),
+                map: self.map_type,
                 relaxed: self.relaxed,
             };
             let structs = analyze(schema, kind, cfg)?

--- a/src/output.rs
+++ b/src/output.rs
@@ -193,6 +193,7 @@ impl Output {
 
 /// Type used for additionalProperties maps
 #[derive(clap::ValueEnum, Clone, Copy, Default, Debug)]
+#[clap(rename_all = "PascalCase")]
 pub enum MapType {
     #[default]
     BTreeMap,

--- a/src/output.rs
+++ b/src/output.rs
@@ -191,6 +191,22 @@ impl Output {
     }
 }
 
+/// Type used for additionalProperties maps
+#[derive(clap::ValueEnum, Clone, Copy, Default, Debug)]
+pub enum MapType {
+    #[default]
+    BTreeMap,
+    HashMap,
+}
+impl MapType {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BTreeMap => "BTreeMap",
+            Self::HashMap => "HashMap",
+        }
+    }
+}
+
 // unit tests
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
follow-up to #218

reverts the change that partially changes the default map type.

after this change we still maintain `BTreeMap`, but use it in a few more places consistently.