### PR TITLE
add a configurable `--no-import` flag for granular import control

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,4 @@
 mod analyzer;
 pub use analyzer::{analyze, Config};
 mod output;
-pub use output::{Container, MapType, Member, Output};
+pub use output::{Container, Import, MapType, Member, Output};

--- a/src/output.rs
+++ b/src/output.rs
@@ -208,6 +208,20 @@ impl MapType {
     }
 }
 
+/// Types we explicitly allow hiding from the prelude
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq)]
+#[clap(rename_all = "PascalCase")]
+pub enum Import {
+    Serde,
+    Maps,
+    Chrono,
+    Builder,
+    Schemars,
+    IntOrString,
+    Condition,
+    Kube,
+}
+
 // unit tests
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
allows more control than `--hide-prelude` which disables everything, but is also likely to break for people who only override one struct, because we might add more structs to our prelude.

fixes #214