### PR TITLE
feat: generalized approach to derive traits on top level struct

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -245,6 +245,12 @@ impl Kopium {
                     if self.schema != "derived" {
                         println!(r#"#[kube(schema = "{}")]"#, self.schema);
                     }
+                    for trait_to_derive in &self.derive {
+                        if trait_to_derive == "JsonSchema" {
+                            continue;
+                        }
+                        println!(r#"#[kube(derive="{}")]"#, trait_to_derive);
+                    }
                 }
                 if s.is_enum {
                     println!("pub enum {} {{", s.name);


### PR DESCRIPTION
Part of #232 

Generates `#kube[(derive="Trait")]` for each trait (except `JsonSchema`) passed in to kopium using the `--derive` flag. For more info see: https://docs.rs/kube/latest/kube/derive.CustomResource.html#kubederive--trait