### PR TITLE
Make `--derive` more flexible

### DIFF
--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,0 +1,108 @@
+use anyhow::anyhow;
+use std::str::FromStr;
+
+use crate::Container;
+
+/// Target object for which the trait must be derived.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeriveTarget {
+    /// Derive the trait for all types
+    All,
+    /// Derive the trait for a named type only.
+    Type(String),
+    /// Derive the trait for all structs.
+    Structs,
+    /// Derive the trait for enums, optionally only for simple
+    /// ([unit-only](https://doc.rust-lang.org/reference/items/enumerations.html)) enums.
+    Enums {
+        /// Limit trait derivation to *unit-only* enums.
+        unit_only: bool,
+    },
+}
+
+/// A trait to derive, as well as the object for which to derive it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Derive {
+    /// Target object (type, structs, enums) to derive the trait for.
+    pub target: DeriveTarget,
+    /// Trait to derive for the target.
+    pub derived_trait: String,
+}
+
+impl Derive {
+    /// Construct a derived trait targeting All objects.
+    pub fn all(derived_trait: &str) -> Self {
+        Derive {
+            target: DeriveTarget::All,
+            derived_trait: derived_trait.to_owned(),
+        }
+    }
+
+    pub fn is_applicable_to(&self, s: &Container) -> bool {
+        if s.is_enum && self.derived_trait == "Default" {
+            // Need to drop Default from enum as this cannot be derived.
+            // Enum defaults need to either be manually derived
+            // or we can insert enum defaults
+            return false;
+        }
+
+        // Only insert the trait if the target matches our container.
+        match &self.target {
+            DeriveTarget::All => true,
+            DeriveTarget::Type(name) => &s.name == name,
+            DeriveTarget::Structs => !s.is_enum,
+            DeriveTarget::Enums { unit_only } => {
+                if s.is_enum {
+                    return false;
+                }
+
+                if *unit_only && s.members.iter().any(|member| member.type_.is_empty()) {
+                    return false;
+                }
+
+                true
+            }
+        }
+    }
+}
+
+impl FromStr for Derive {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> std::prelude::v1::Result<Self, Self::Err> {
+        if let Some((target, derived_trait)) = value.split_once('=') {
+            if target.is_empty() {
+                return Err(anyhow!("derive target cannot be empty in '{value}'"));
+            };
+
+            if derived_trait.is_empty() {
+                return Err(anyhow!("derived trait cannot be empty in '{value}'"));
+            }
+
+            let target = if let Some(target) = target.strip_prefix('@') {
+                match target {
+                    "struct" | "structs" => DeriveTarget::Structs,
+                    "enum" | "enums" => DeriveTarget::Enums { unit_only: false },
+                    "enum:simple" | "enums:simple" => DeriveTarget::Enums { unit_only: true },
+                    other => {
+                        return Err(anyhow!(
+                            "unknown derive target @{other}, must be one of @struct, @enum, or @enum:simple"
+                        ))
+                    }
+                }
+            } else {
+                DeriveTarget::Type(target.to_owned())
+            };
+
+            Ok(Derive {
+                target,
+                derived_trait: derived_trait.to_owned(),
+            })
+        } else {
+            Ok(Derive {
+                target: DeriveTarget::All,
+                derived_trait: value.to_owned(),
+            })
+        }
+    }
+}

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -196,3 +196,43 @@ fn derive_applicability() {
     assert!(named_struct_trait.is_applicable_to(&named_structure));
     assert!(!named_struct_trait.is_applicable_to(&named_enum));
 }
+
+#[test]
+fn test_derive_parsing() {
+    assert_eq!("PartialEq".parse::<Derive>().unwrap(), Derive::all("PartialEq"));
+
+    assert_eq!("@struct=PartialEq".parse::<Derive>().unwrap(), Derive {
+        target: DeriveTarget::Structs,
+        derived_trait: "PartialEq".to_string()
+    });
+
+    assert_eq!("@enum=PartialEq".parse::<Derive>().unwrap(), Derive {
+        target: DeriveTarget::Enums { unit_only: false },
+        derived_trait: "PartialEq".to_string()
+    });
+
+    assert_eq!("@enum:simple=PartialEq".parse::<Derive>().unwrap(), Derive {
+        target: DeriveTarget::Enums { unit_only: true },
+        derived_trait: "PartialEq".to_string()
+    });
+
+    assert_eq!("MyStruct=PartialEq".parse::<Derive>().unwrap(), Derive {
+        target: DeriveTarget::Type("MyStruct".to_string()),
+        derived_trait: "PartialEq".to_string()
+    });
+
+    assert_eq!(
+        "=".parse::<Derive>().unwrap_err().to_string(),
+        "derive target cannot be empty in '='"
+    );
+
+    assert_eq!(
+        "=PartialEq".parse::<Derive>().unwrap_err().to_string(),
+        "derive target cannot be empty in '=PartialEq'"
+    );
+
+    assert_eq!(
+        "@struct=".parse::<Derive>().unwrap_err().to_string(),
+        "derived trait cannot be empty in '@struct='"
+    );
+}

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -41,7 +41,7 @@ impl Derive {
     /// Returns true if this Derive is applicable to the given container.
     ///
     /// See below truth table:
-    /// | Container            Target | All  | Enum { unit_only: true } | Enum { unit_only: false } | Struct | Type("MyStruct") | Type("OtherEnum") |
+    /// | Container                  Target | All  | Enum { unit_only: true } | Enum { unit_only: false } | Struct | Type("MyStruct") | Type("OtherEnum") |
     /// |-----------------------------------|------|--------------------------|---------------------------|--------|------------------|-------------------|
     /// | enum Simple { A, B }              | true | true                     | true                      | false  | false            | false             |
     /// | enum Complex { A, B { b: bool } } | true | false                    | true                      | false  | false            | false             |

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -41,12 +41,13 @@ impl Derive {
     /// Returns true if this Derive is applicable to the given container.
     ///
     /// See below truth table:
-    /// | Container                  Target | All  | Enum { unit_only: true } | Enum { unit_only: false } | Struct | Type("MyStruct") | Type("OtherEnum") |
+    ///
+    /// | Container      \           Target | `All`|`Enum { unit_only: true }`|`Enum { unit_only: false }`|`Struct`|`Type("MyStruct")`|`Type("OtherEnum")`|
     /// |-----------------------------------|------|--------------------------|---------------------------|--------|------------------|-------------------|
-    /// | enum Simple { A, B }              | true | true                     | true                      | false  | false            | false             |
-    /// | enum Complex { A, B { b: bool } } | true | false                    | true                      | false  | false            | false             |
-    /// | struct MyStruct { .. }            | true | false                    | false                     | true   | true             | false             |
-    /// | enum OtherEnum { A, B }           | true | false                    | false                     | true   | false            | true              |
+    /// |`enum Simple { A, B }`             |`true`|`true`                    |`true`                     |`false` |`false`           |`false`            |
+    /// |`enum Complex { A, B { b: bool } }`|`true`|`false`                   |`true`                     |`false` |`false`           |`false`            |
+    /// |`struct MyStruct { .. }`           |`true`|`false`                   |`false`                    |`true`  |`true`            |`false`            |
+    /// |`enum OtherEnum { A, B }`          |`true`|`false`                   |`false`                    |`true`  |`false`           |`true`             |
     ///
     pub fn is_applicable_to(&self, s: &Container) -> bool {
         match &self.target {

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -197,6 +197,7 @@ fn derive_applicability() {
     assert!(!named_struct_trait.is_applicable_to(&named_enum));
 }
 
+#[cfg(test)]
 #[test]
 fn test_derive_parsing() {
     assert_eq!("PartialEq".parse::<Derive>().unwrap(), Derive::all("PartialEq"));

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -5,7 +5,7 @@ use crate::Container;
 
 /// Target object for which the trait must be derived.
 #[derive(Debug, Clone, PartialEq)]
-pub enum DeriveTarget {
+enum Target {
     /// Derive the trait for all types
     All,
     /// Derive the trait for a named type only.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,4 @@ pub use analyzer::{analyze, Config};
 mod output;
 pub use output::{Container, MapType, Member, Output};
 mod derive;
-pub use derive::{Derive, DeriveTarget};
+pub use derive::Derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@ mod analyzer;
 pub use analyzer::{analyze, Config};
 mod output;
 pub use output::{Container, MapType, Member, Output};
+mod derive;
+pub use derive::{Derive, DeriveTarget};

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,7 @@ impl Kopium {
     }
 
     fn print_derives(&self, s: &Container) {
-        let mut derives: Vec<String> = vec!["Serialize", "Deserialize", "Clone", "Debug"]
+        let mut derives: Vec<String> = ["Serialize", "Deserialize", "Clone", "Debug"]
             .into_iter()
             .map(String::from)
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,7 +327,7 @@ impl Kopium {
         if self.builders {
             derives.push("TypedBuilder".to_string());
         }
-        if s.is_enum {
+        if s.is_enum && s.members.iter().all(|member| member.type_.is_empty()) {
             derives.extend(
                 ["PartialEq", "Eq", "PartialOrd", "Ord"]
                     .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,7 +421,7 @@ impl Kopium {
         }
 
         for derive in &self.derive {
-            if derive.derived_trait == "Default" && s.is_enum {
+            if s.is_enum && derive.derived_trait == "Default" {
                 // Need to drop Default from enum as this cannot be derived.
                 // Enum defaults need to either be manually derived
                 // or we can insert enum defaults

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ struct Kopium {
     /// There are three different ways of specifying traits to derive:
     ///
     /// 1. A plain trait name will implement the trait for *all* objects generated from
-    ///    the custom resource definition: `--derive PartialEq --derive Eq`
+    ///    the custom resource definition: `--derive PartialEq`
     ///
     /// 2. Constraining the derivation to a singular struct or enum:
     ///    `--derive IssuerAcmeSolversDns01CnameStrategy=PartialEq`

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ struct Kopium {
 
     /// Derive these additional traits on generated objects
     ///
-    /// There are several different ways of specifying traits to derive:
+    /// There are three different ways of specifying traits to derive:
     ///
     /// 1. A plain trait name will implement the trait for *all* objects generated from
     ///    the custom resource definition: `--derive PartialEq --derive Eq`

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,6 +350,13 @@ impl Kopium {
         }
 
         for derive in &self.derive {
+            if s.is_enum && derive.derived_trait == "Default" {
+                // Need to drop Default from enum as this cannot be derived.
+                // Enum defaults need to either be manually derived
+                // or we can insert enum defaults
+                continue;
+            }
+
             if derive.is_applicable_to(s) && !derives.contains(&derive.derived_trait.as_str()) {
                 derives.push(&derive.derived_trait)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,14 @@ impl Kopium {
         if self.builders {
             derives.push("TypedBuilder".to_string());
         }
+        if s.is_enum {
+            derives.extend(
+                ["PartialEq", "Eq", "PartialOrd", "Ord"]
+                    .into_iter()
+                    .map(String::from),
+            );
+        }
+
         // add user derives last in order
         for d in &self.derive {
             if s.is_enum && d == "Default" {
@@ -335,7 +343,9 @@ impl Kopium {
                 // or we can insert enum defaults
                 continue;
             }
-            derives.push(d.clone());
+            if !derives.contains(d) {
+                derives.push(d.clone());
+            }
         }
         println!("#[derive({})]", derives.join(", "));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,20 +435,8 @@ impl Kopium {
             // Only insert the trait if the target matches our container.
             if let Some(derived_trait) = match &derive.target {
                 DeriveTarget::All => Some(&derive.derived_trait),
-                DeriveTarget::Type(name) => {
-                    if &s.name == name {
-                        Some(&derive.derived_trait)
-                    } else {
-                        None
-                    }
-                }
-                DeriveTarget::Structs => {
-                    if !s.is_enum {
-                        Some(&derive.derived_trait)
-                    } else {
-                        None
-                    }
-                }
+                DeriveTarget::Type(name) => (&s.name == name).then_some(&derive.derived_trait),
+                DeriveTarget::Structs => s.is_enum.then_some(&derive.derived_trait),
                 DeriveTarget::Enums { unit_only } => {
                     if s.is_enum && (!unit_only || s.members.iter().all(|member| member.type_.is_empty())) {
                         Some(&derive.derived_trait)

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,8 @@ struct Kopium {
     /// 3. Constraining the derivation to only structs (@struct), enums (@enum) or *unit-only* enums (@enum:simple),
     ///    meaning enums where no variants are tuple or structs:
     ///    `--derive @struct=PartialEq`, `--derive @enum=PartialEq`, `--derive @enum:simple=PartialEq`
+    ///
+    /// See also: https://doc.rust-lang.org/reference/items/enumerations.html
     #[arg(long,
         short = 'D',
         value_parser = parse_derive,

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ fn get_stdin_data() -> Result<String> {
 enum DeriveTarget {
     /// Derive the trait for all types
     All,
-    /// Derive the trait for a specific type only.
+    /// Derive the trait for a named type only.
     Type(String),
     /// Derive the trait for all structs.
     Structs,


### PR DESCRIPTION
Fixes #231 

This overhauls the `--derive` flag in a backwards compatible way, allowing users to specify traits to derive on a per-object basis, on all structs, all enums, or just [unit-only](https://doc.rust-lang.org/reference/items/enumerations.html) enums.

From the updated help text:

>  -D, --derive <DERIVE>
>
>  Derive these additional traits on generated objects
>  
>  There are three different ways of specifying traits to derive:
>  
>  1. A plain trait name will implement the trait for *all* objects generated from the custom resource definition: `--derive PartialEq`
>  
>  2. Constraining the derivation to a singular struct or enum: `--derive IssuerAcmeSolversDns01CnameStrategy=PartialEq`
>  
>  3. Constraining the derivation to only structs (`@struct`), enums (`@enum`) or *unit-only* enums (`@enum:simple`), meaning enums where no variants are tuple or structs: `--derive @struct=PartialEq`, `--derive @enum=PartialEq`, `--derive @enum:simple=PartialEq`
>  
>  See also: https://doc.rust-lang.org/reference/items/enumerations.html

I'm still not entirely sure if the `enum:simple` syntax is the right way to go. I experimented with inverting it so `enum` matched only the simple enums, and you had to do `enum+complex` to trigger derivation for complex types, but that was even less intuitive since you would expect `enum` to cover all enums by default.