### PR TITLE
Improve detecting whether default can be derived

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -5,7 +5,10 @@ use heck::ToUpperCamelCase;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
     JSONSchemaProps, JSONSchemaPropsOrArray, JSONSchemaPropsOrBool, JSON,
 };
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    cell::OnceCell,
+    collections::{BTreeMap, HashMap},
+};
 
 const IGNORED_KEYS: [&str; 3] = ["metadata", "apiVersion", "kind"];
 
@@ -225,6 +228,7 @@ fn analyze_enum_properties(
         level,
         docs: schema.description.clone(),
         is_enum: true,
+        supports_derive_default: OnceCell::new(),
     })
 }
 
@@ -333,6 +337,7 @@ fn extract_container(
         level,
         docs: schema.description.clone(),
         is_enum: false,
+        supports_derive_default: OnceCell::new(),
     })
 }
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -5,10 +5,7 @@ use heck::ToUpperCamelCase;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
     JSONSchemaProps, JSONSchemaPropsOrArray, JSONSchemaPropsOrBool, JSON,
 };
-use std::{
-    cell::OnceCell,
-    collections::{BTreeMap, HashMap},
-};
+use std::collections::{BTreeMap, HashMap};
 
 const IGNORED_KEYS: [&str; 3] = ["metadata", "apiVersion", "kind"];
 
@@ -228,7 +225,7 @@ fn analyze_enum_properties(
         level,
         docs: schema.description.clone(),
         is_enum: true,
-        supports_derive_default: OnceCell::new(),
+        ..Container::default()
     })
 }
 
@@ -337,7 +334,7 @@ fn extract_container(
         level,
         docs: schema.description.clone(),
         is_enum: false,
-        supports_derive_default: OnceCell::new(),
+        ..Container::default()
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,12 @@ struct Kopium {
     /// Type used to represent maps via additionalProperties
     #[arg(long, value_enum, default_value_t)]
     map_type: MapType,
+    
+    /// Always add #[derive(Default)] to structs, even if it can't be derived without a manual impl for some fields
+    /// 
+    /// This option only has an effect if `--derive Default` is set.
+    #[arg(long)]
+    force_derive_default: bool,
 }
 
 #[derive(Clone, Copy, Debug, Subcommand)]
@@ -268,7 +274,7 @@ impl Kopium {
                         if derive.derived_trait == "JsonSchema" {
                             continue;
                         }
-                        if derive.derived_trait == "Default" && !s.can_derive_default(&structs) {
+                        if derive.derived_trait == "Default" && !self.force_derive_default && !s.can_derive_default(&structs) {
                             continue;
                         }
                         println!(r#"#[kube(derive="{}")]"#, derive.derived_trait);
@@ -356,7 +362,7 @@ impl Kopium {
 
         for derive in &self.derive {
             if derive.derived_trait == "Default" {
-                if !s.can_derive_default(containers) {
+                if !s.can_derive_default(containers) || (self.force_derive_default && !s.is_enum) {
                     continue;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,9 +121,9 @@ struct Kopium {
     /// Type used to represent maps via additionalProperties
     #[arg(long, value_enum, default_value_t)]
     map_type: MapType,
-    
+
     /// Always add #[derive(Default)] to structs, even if it can't be derived without a manual impl for some fields
-    /// 
+    ///
     /// This option only has an effect if `--derive Default` is set.
     #[arg(long)]
     force_derive_default: bool,
@@ -274,7 +274,10 @@ impl Kopium {
                         if derive.derived_trait == "JsonSchema" {
                             continue;
                         }
-                        if derive.derived_trait == "Default" && !self.force_derive_default && !s.can_derive_default(&structs) {
+                        if derive.derived_trait == "Default"
+                            && !self.force_derive_default
+                            && !s.can_derive_default(&structs)
+                        {
                             continue;
                         }
                         println!(r#"#[kube(derive="{}")]"#, derive.derived_trait);

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,6 +268,9 @@ impl Kopium {
                         if derive.derived_trait == "JsonSchema" {
                             continue;
                         }
+                        if derive.derived_trait == "Default" && !s.can_derive_default(&structs) {
+                            continue;
+                        }
                         println!(r#"#[kube(derive="{}")]"#, derive.derived_trait);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,11 +122,11 @@ struct Kopium {
     #[arg(long, value_enum, default_value_t)]
     map_type: MapType,
 
-    /// Always add #[derive(Default)] to structs, even if it can't be derived without a manual impl for some fields
+    /// Automatically removes #[derive(Default)] from structs that contain fields for which a default can not be automatically derived.
     ///
     /// This option only has an effect if `--derive Default` is set.
     #[arg(long)]
-    force_derive_default: bool,
+    smart_derive_elision: bool,
 }
 
 #[derive(Clone, Copy, Debug, Subcommand)]
@@ -275,7 +275,7 @@ impl Kopium {
                             continue;
                         }
                         if derive.derived_trait == "Default"
-                            && !self.force_derive_default
+                            && self.smart_derive_elision
                             && !s.can_derive_default(&structs)
                         {
                             continue;
@@ -365,7 +365,7 @@ impl Kopium {
 
         for derive in &self.derive {
             if derive.derived_trait == "Default" {
-                if !s.can_derive_default(containers) || (self.force_derive_default && !s.is_enum) {
+                if (self.smart_derive_elision && !s.can_derive_default(containers)) || !s.is_enum {
                     continue;
                 }
             }

--- a/src/output.rs
+++ b/src/output.rs
@@ -253,8 +253,6 @@ impl MapType {
 // unit tests
 #[cfg(test)]
 mod test {
-    use std::cell::OnceCell;
-
     use super::{Container, Member};
     fn name_only_enum_member(name: &str) -> Member {
         Member {
@@ -291,9 +289,8 @@ mod test {
                 name_only_enum_member("jwksUri"),
                 name_only_enum_member("JwksUri"),
             ],
-            docs: None,
             is_enum: true,
-            supports_derive_default: OnceCell::new(),
+            ..Container::default()
         };
 
         c.rename();
@@ -317,9 +314,7 @@ mod test {
                 name_only_int_member("jwksUri"),
                 name_only_int_member("JwksUri"),
             ],
-            docs: None,
-            is_enum: false,
-            supports_derive_default: OnceCell::new(),
+            ..Container::default()
         };
         cs.rename();
         assert_eq!(&cs.members[0].name, "jwks_uri");
@@ -334,18 +329,13 @@ mod test {
             Container {
                 name: "Simple".to_string(),
                 level: 1,
-                members: vec![],
-                docs: None,
-                is_enum: false,
-                supports_derive_default: OnceCell::new(),
+                ..Container::default()
             },
             Container {
                 name: "Enum".to_string(),
                 level: 1,
-                members: vec![],
-                docs: None,
                 is_enum: true,
-                supports_derive_default: OnceCell::new(),
+                ..Container::default()
             },
             Container {
                 name: "Nested".to_string(),
@@ -353,13 +343,9 @@ mod test {
                 members: vec![Member {
                     name: "simple".to_string(),
                     type_: "Simple".to_string(),
-                    serde_annot: vec![],
-                    extra_annot: vec![],
-                    docs: None,
+                    ..Member::default()
                 }],
-                docs: None,
-                is_enum: false,
-                supports_derive_default: OnceCell::new(),
+                ..Container::default()
             },
             Container {
                 name: "ReferencesEnum".to_string(),
@@ -367,13 +353,9 @@ mod test {
                 members: vec![Member {
                     name: "enum".to_string(),
                     type_: "Enum".to_string(),
-                    serde_annot: vec![],
-                    extra_annot: vec![],
-                    docs: None,
+                    ..Member::default()
                 }],
-                docs: None,
-                is_enum: false,
-                supports_derive_default: OnceCell::new(),
+                ..Container::default()
             },
             Container {
                 name: "ReferencesEnumNested".to_string(),
@@ -381,13 +363,9 @@ mod test {
                 members: vec![Member {
                     name: "references_enum".to_string(),
                     type_: "ReferencesEnum".to_string(),
-                    serde_annot: vec![],
-                    extra_annot: vec![],
-                    docs: None,
+                    ..Member::default()
                 }],
-                docs: None,
-                is_enum: false,
-                supports_derive_default: OnceCell::new(),
+                ..Container::default()
             },
             Container {
                 name: "ReferencesEnumOption".to_string(),
@@ -395,13 +373,9 @@ mod test {
                 members: vec![Member {
                     name: "maybe_enum".to_string(),
                     type_: "Option<Enum>".to_string(),
-                    serde_annot: vec![],
-                    extra_annot: vec![],
-                    docs: None,
+                    ..Member::default()
                 }],
-                docs: None,
-                is_enum: false,
-                supports_derive_default: OnceCell::new(),
+                ..Container::default()
             },
             Container {
                 name: "ReferencesEnumVec".to_string(),
@@ -409,13 +383,9 @@ mod test {
                 members: vec![Member {
                     name: "enum_list".to_string(),
                     type_: "Vec<Enum>".to_string(),
-                    serde_annot: vec![],
-                    extra_annot: vec![],
-                    docs: None,
+                    ..Member::default()
                 }],
-                docs: None,
-                is_enum: false,
-                supports_derive_default: OnceCell::new(),
+                ..Container::default()
             },
             Container {
                 name: "ReferencesEnumNestedOption".to_string(),
@@ -423,13 +393,9 @@ mod test {
                 members: vec![Member {
                     name: "maybe_references_enum".to_string(),
                     type_: "Option<ReferencesEnum>".to_string(),
-                    serde_annot: vec![],
-                    extra_annot: vec![],
-                    docs: None,
+                    ..Member::default()
                 }],
-                docs: None,
-                is_enum: false,
-                supports_derive_default: OnceCell::new(),
+                ..Container::default()
             },
         ];
         assert!(containers[0].can_derive_default(&containers)); // Simple


### PR DESCRIPTION
This checks if a struct contains a required member for which `Default` is not implemented (Enums or other structs which don't have `Default`). If it does, Default will not be derived for that struct.