### PR TITLE
link to group binding library - add istio-api-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The main catalogue library is [metio/kube-custom-resources-rs](https://github.co
 
 Specific group binding libraries:
 - [gateway-api-rs](https://github.com/kube-rs/gateway-api-rs)
+- [istio-api-rs](https://github.com/BlankZhu/istio-api-rs)
 
 Feel free to [edit this file](https://github.com/kube-rs/kopium/edit/main/README.md) to add more.
 


### PR DESCRIPTION
Hats off to kopium developers.

I've been maintaining a repository ([istio-api-rs](https://github.com/BlankZhu/istio-api-rs), or on [crates.io](https://crates.io/crates/istio-api-rs)) using `kopium` to generate rust CRD codes for istio for a while. 

Kopium is actually a promising codegen tool in rust. So I think it would be a good idea to add it to the `Existing Bindings` section as a group binding library like gateway-api-rs.