### PR TITLE
Fix: make derive default work again

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -365,7 +365,7 @@ impl Kopium {
 
         for derive in &self.derive {
             if derive.derived_trait == "Default"
-                && ((self.smart_derive_elision && !s.can_derive_default(containers)) || !s.is_enum)
+                && ((self.smart_derive_elision && !s.can_derive_default(containers)) || s.is_enum)
             {
                 continue;
             }


### PR DESCRIPTION
I accidentally skipped it for all structs instead of all enums...

Fixes a bug in #241.