### PR TITLE
Escape code blocks in rustdocs with `text` attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "heck",
  "k8s-openapi",
  "kube",
+ "lazy_static",
  "libc",
  "log",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,7 @@ dependencies = [
  "libc",
  "log",
  "quote",
+ "regex",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ heck = "0.5.0"
 syn = "2.0.77"
 libc = "0.2.158"
 regex = "1.10.6"
+lazy_static = "1.5.0"
 
 [dependencies.k8s-openapi]
 version = "0.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde_yaml = "0.9.34"
 heck = "0.5.0"
 syn = "2.0.77"
 libc = "0.2.158"
+regex = "1.10.6"
 
 [dependencies.k8s-openapi]
 version = "0.22.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,6 @@
 mod analyzer;
 pub use analyzer::{analyze, Config};
 mod output;
-pub use output::{Container, MapType, Member, Output};
+pub use output::{format_docstr, Container, MapType, Member, Output};
 mod derive;
 pub use derive::Derive;

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,8 +352,8 @@ impl Kopium {
         // print doc strings if requested in arguments
         if self.docs {
             if let Some(d) = doc {
-                println!("{}/// {}", indent, d.replace('\n', &format!("\n{}/// ", indent)));
                 // TODO: maybe logic to split doc strings by sentence / length here
+                println!("{}", format_docstr(indent, d));
             }
         }
     }
@@ -474,4 +474,13 @@ fn all_versions(crd: &CustomResourceDefinition) -> String {
         .collect::<Vec<_>>();
     vers.sort_by_cached_key(|v| std::cmp::Reverse(Version::parse(v).priority()));
     vers.join(", ")
+}
+
+fn format_docstr(indent: &str, input: &str) -> String {
+    // TODO: maybe logic to split doc strings by sentence / length here
+    format!(
+        "{}/// {}",
+        indent,
+        input.replace('\n', &format!("\n{}/// ", indent))
+    )
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -488,6 +488,5 @@ mod test {
             "/// Some docs\n/// ```text\n/// foobar\n/// ```\n/// Some more docs\n/// ```text\n/// foobar.more\n/// ```",
             format_docstr("", "Some docs\n```\nfoobar\n```\nSome more docs\n```\nfoobar.more\n```")
         );
-
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,7 +1,15 @@
 use std::cell::OnceCell;
 
 use heck::{ToPascalCase, ToSnakeCase};
-use regex::RegexBuilder;
+use lazy_static::lazy_static;
+use regex::{Regex, RegexBuilder};
+
+lazy_static! {
+    static ref RE_CODEBLOCK: Regex = RegexBuilder::new(r"```.*\n([\s\S]+)\n```")
+        .swap_greed(true)
+        .build()
+        .unwrap();
+}
 
 /// All found containers
 pub struct Output(pub Vec<Container>);
@@ -257,11 +265,7 @@ impl MapType {
 }
 
 pub fn format_docstr(indent: &str, input: &str) -> String {
-    let re = RegexBuilder::new(r"```.*\n([\s\S]+)\n```")
-        .swap_greed(true)
-        .build()
-        .unwrap();
-    let cleaned_input = re.replace_all(input, "```text\n$1\n```").to_owned();
+    let cleaned_input = RE_CODEBLOCK.replace_all(input, "```text\n$1\n```");
     // TODO: maybe logic to split doc strings by sentence / length here
 
     format!(


### PR DESCRIPTION
I split the PR in two: 
 - Open the seam to write a test
 - Add the test and propose a fix to impl (which might not be the most elegant, so open for debate 😉 )

Should fix #264 