### PR TITLE
preserve top level labels and annotations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,10 @@ pub struct TypeGenerator {
     #[cfg_attr(feature = "cli", arg(short = 'd', long = "docs"))]
     pub emit_docs: bool,
 
+    /// Preserve top-level annotations and labels from source CRD
+    #[cfg_attr(feature = "cli", arg(short = 'm', long = "preserve-metadata"))]
+    pub preserve_metadata: bool,
+
     /// Emit builder derives via the [`typed-builder`](typed_builder) crate
     #[cfg_attr(
         feature = "cli",
@@ -289,6 +293,14 @@ impl TypeGenerator {
 
                     if scope == "Namespaced" {
                         writeln!(&mut generated, r#"#[kube(namespaced)]"#)?;
+                    }
+                    if self.preserve_metadata {
+                        for (k, v) in crd.annotations() {
+                            writeln!(&mut generated, r#"#[kube(annotation("{}", "{}"))]"#, k, v)?;
+                        }
+                        for (k, v) in crd.labels() {
+                            writeln!(&mut generated, r#"#[kube(label("{}", "{}"))]"#, k, v)?;
+                        }
                     }
 
                     // status should be listed as a subresource

--- a/tests/cmd/help/help.md
+++ b/tests/cmd/help/help.md
@@ -35,6 +35,9 @@ Options:
   -d, --docs
           Emit doc comments from CRD field descriptions
 
+  -m, --preserve-metadata
+          Preserve top-level annotations and labels from source CRD
+
   -b, --builders
           Emit builder derives via the `typed-builder` crate
 


### PR DESCRIPTION
Currently kopium throws away input_crd.metadata.annotations and input_crd.metadata.labels when it should be passing them on to kube's customderive [`#[kube(annotation(k,v))`](https://docs.rs/kube/latest/kube/derive.CustomResource.html#kubeannotationannotation_key-annotation_value) and [`#[kube(label(k,v))`](https://docs.rs/kube/latest/kube/derive.CustomResource.html#kubelabellabel_key-label_value).

This PR adds a new `--preserve-metadata` or `-m` flag to keep these and emit them into the generated struct.

This __can__ be noisy. I tested it on a rancher crd and i got this stuff;

```rust
#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
#[kube(group = "k3s.cattle.io", version = "v1", kind = "Addon", plural = "addons")]
#[kube(namespaced)]
#[kube(annotation("objectset.rio.cattle.io/applied", "H4sIAAAAAAAA/4xSQY8TPQz9K598zjcsnd22jMRhVYSEkFYVC72gPbiJ22abSaI40wVV89+Rp50pFFo4+tl+frbfHjDaBSW2wUMlAX3L5CXkYjvlwoZXu9egYGu9gQpmDedQfyIOTXjlbW2yy9XXXXmrKaDAjVHtA70NGSbCEYflMOjPlItlQaMzZkTBboQR1MR9ePKX/17vtZWnqv4/Wm7dXdF0n91iTsBvT0ZZ8qvinXo6ohQBaBTpRt/NnWxNnrCNUvnFOgcMluauX2CBvoILJ+ObNSJu72yWOy5WelNpMltPJaHo7GtOY7mhyU5ZkSKZdU94q4EhaJq5TaCJUcL5aJ14Kjp+9Fx5QEF2T0A3EoICtXzcOU43Je0zElHb0xW99ePHvLTnAUKXQMSlgHaJoe+gPZEDB7uAyhurrXoi6/6CbJ+szpVlwTX1MPnPwc8xykELWKA5fhWHnxz7O37s5nJP1a2jVH3r1hvSWm/rUPTshZ/1PQ03nedYbqjs/h0j+fv5hUT4OUEwhUsr2cMT+2r+iw+xqD+IEXDqCKqeGfpcOxyX/XtoOyMFNF5DuP6bn4BwSro+U7ZPkM+amk4laU8xkHs4s8bMbOn8Hf/ga98YWVjKL4bOCtu2PAAAA//+gOtjyVQQAAA"))]
#[kube(annotation("objectset.rio.cattle.io/id", ""))]
#[kube(annotation("objectset.rio.cattle.io/owner-gvk", "apiextensions.k8s.io/v1, Kind=CustomResourceDefinition"))]
#[kube(annotation("objectset.rio.cattle.io/owner-name", "addons.k3s.cattle.io"))]
#[kube(annotation("objectset.rio.cattle.io/owner-namespace", ""))]
#[kube(label("objectset.rio.cattle.io/hash", "76092cd54ba63fc73cd7b8728426e6e5e7033ede"))]
pub struct AddonSpec {
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub checksum: Option<String>,
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub source: Option<String>,
}
```

but there are good reasons to preserve them for some people; https://github.com/kube-rs/kopium/issues/458

